### PR TITLE
DEVX-2905 Normalized Page Titles

### DIFF
--- a/lib/nexmo_developer/app/presenters/page_title.rb
+++ b/lib/nexmo_developer/app/presenters/page_title.rb
@@ -6,11 +6,26 @@ class PageTitle
 
   def title
     if @product && @document_title
-      "#{@product.titleize} > #{@document_title} | #{default_title}"
+      "#{product_title_from_config(@product)} > #{@document_title} | #{default_title}"
     elsif @document_title
       "#{@document_title} | #{default_title}"
     else
       default_title
+    end
+  end
+
+  def product_title_from_config(product)
+    config = load_config
+    item = config['products'].select { |config_product| config_product['path'] == product }[0]
+    item['name']
+  end
+
+  def load_config
+    @load_config ||= begin
+      path ||= "#{Rails.configuration.docs_base_path}/config/products.yml"
+      raise 'You must provide a config/products.yml file in your documentation path.' unless File.exist?(path)
+
+      YAML.safe_load(File.open(path))
     end
   end
 

--- a/lib/nexmo_developer/spec/presenters/page_title_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/page_title_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe PageTitle, type: :model do
       let(:title) { 'Metadata Example Title' }
 
       context 'with product' do
-        let(:product) { 'Example Product' }
+        let(:product) { 'example/example-api' }
 
         it 'returns the product and title with the default appended' do
-          expect(subject.title).to eq('Example Product > Metadata Example Title | Vonage API Developer')
+          allow_any_instance_of(PageTitle).to receive(:load_config).and_return(sample_config)
+          expect(subject.title).to eq('Example API > Metadata Example Title | Vonage API Developer')
         end
       end
 
@@ -31,5 +32,19 @@ RSpec.describe PageTitle, type: :model do
         expect(subject.title).to eq('Vonage API Developer')
       end
     end
+  end
+
+  def sample_config
+    {
+      'products' => [
+        {
+          'name' => 'Example API',
+          'icon' => 'user',
+          'icon_colour' => 'purple-dark',
+          'path' => 'example/example-api',
+          'dropdown' => true,
+        },
+      ],
+    }
   end
 end


### PR DESCRIPTION
Currently, on NDP all page titles come out as the following: 

> Voice/voice Api > Numbers | Vonage API Developer

This PR adds a new method to the `PageTitle` presenter to normalize the page titles so that they show as the following:

> Voice/Voice API > Numbers | Vonage API Developer
