### PR TITLE
Fix sidenav for ja/cn.

### DIFF
--- a/lib/nexmo_developer/app/presenters/sidenav_resolver.rb
+++ b/lib/nexmo_developer/app/presenters/sidenav_resolver.rb
@@ -119,7 +119,7 @@ class SidenavResolver
   private
 
   def documentation_index?(path)
-    path == "#{Rails.configuration.docs_base_path}/_documentation/#{@language}/index.md"
+    path == "#{Rails.configuration.docs_base_path}/_documentation/#{I18n.default_locale}/index.md"
   end
 
   def tabbed_folder?(full_path)

--- a/lib/nexmo_developer/spec/presenters/sidenav_resolver_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/sidenav_resolver_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe SidenavResolver do
         expect(subject.items.size).to eq(3)
       end
     end
+
+    context 'it should exclude `documentation` for other languages' do
+      let(:language) { 'ja' }
+
+      it 'returns the files under the path' do
+        expect(subject.items.size).to eq(3)
+      end
+    end
   end
 
   describe '#directories' do


### PR DESCRIPTION
## Description

There was an extra item showing up, due to `_documentation/en/index`
which is the documentation's homepage defined only in en.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
