### PR TITLE
Fix header in small screens

### DIFF
--- a/lib/nexmo_developer/app/presenters/header.rb
+++ b/lib/nexmo_developer/app/presenters/header.rb
@@ -1,45 +1,56 @@
 class Header
-  attr_reader :items
-
-  def initialize(items: nil)
-    @items = items
-
+  def initialize
     after_initialize!
   end
 
-  def header_from_config(config)
-    config = YAML.safe_load(open_config(config))
-
-    {
-      name: config['name'],
-      subtitle: config['subtitle'],
-      logo_path: config['assets']['header_logo']['path'],
-      logo_alt: config['assets']['header_logo']['alt'],
-      sign_up_path: config['header']['links']['sign-up']['path'],
-      sign_up_text_arr: config['header']['links']['sign-up']['text'],
-      show_hiring_link: hiring_display(config),
-    }
+  def logo_path
+    @logo_path ||= config['assets']['header_logo']['path']
   end
 
-  def open_config(config)
-    File.open(config)
+  def small_logo_path
+    @small_logo_path ||= config['assets']['header_logo']['small_path'] ||
+                         config['assets']['header_logo']['path']
   end
 
-  def config_exist?(path)
-    File.exist?(path)
+  def logo_alt
+    @logo_alt ||= config['assets']['header_logo']['alt']
   end
 
-  def hiring_display(config)
-    raise 'You must provide a true or false value for the hiring display parameter inside the header section of the config/business_info.yml file' unless config['header']['hiring'].try(:has_key?, 'display')
+  def name
+    @name ||= config['name']
+  end
 
-    config['header']['hiring']['display']
+  def subtitle
+    @subtitle ||= config['subtitle']
+  end
+
+  def hiring_link?
+    hiring_display
+  end
+
+  def sign_up_path
+    @sign_up_path ||= config['header']['links']['sign-up']['path']
+  end
+
+  def sign_up_text
+    @sign_up_text ||= config['header']['links']['sign-up']['text']
   end
 
   private
 
   def after_initialize!
-    raise 'You must provide a config/business_info.yml file in your documentation path.' unless config_exist?("#{Rails.configuration.docs_base_path}/config/business_info.yml")
+    raise 'You must provide a config/business_info.yml file in your documentation path.' unless File.exist?("#{Rails.configuration.docs_base_path}/config/business_info.yml")
+  end
 
-    @items = header_from_config("#{Rails.configuration.docs_base_path}/config/business_info.yml")
+  def config
+    @config ||= YAML.safe_load(
+      File.open("#{Rails.configuration.docs_base_path}/config/business_info.yml")
+    )
+  end
+
+  def hiring_display
+    raise 'You must provide a true or false value for the hiring display parameter inside the header section of the config/business_info.yml file' unless config['header']['hiring'].try(:has_key?, 'display')
+
+    config['header']['hiring']['display']
   end
 end

--- a/lib/nexmo_developer/app/views/layouts/partials/_header.html.erb
+++ b/lib/nexmo_developer/app/views/layouts/partials/_header.html.erb
@@ -27,8 +27,8 @@
       <a class="Nxd-main-header__link Vlt-M-plus Vlt-black" href="https://vonage.com/communications-apis">Vonage.com</a>
       <%= render partial: 'layouts/partials/locale_switcher' %>
       <a href=<%= header.sign_up_path %> class="Vlt-btn Vlt-btn--secondary Vlt-btn--app" data-ab="try_button_v2"><b>
-          <% ab_test(:try_button_v2, header.sign_up_text.map { |s| ["{ #{s} }", "< #{s} />"] }.flatten) do |s| %>
-            <%= t(".#{s}") %>
+          <% ab_test(:try_button_v2, header.sign_up_text.map { |s| ["{ #{t(".#{s}")} }", "< #{t(".#{s}")} />"] }.flatten) do |s| %>
+            <%= s %>
           <% end %>
         </b>
       </a>

--- a/lib/nexmo_developer/app/views/layouts/partials/_header.html.erb
+++ b/lib/nexmo_developer/app/views/layouts/partials/_header.html.erb
@@ -1,22 +1,22 @@
+<% header = Header.new %>
 <%= render partial: 'layouts/partials/post-body-tags' %>
 
 <div class="Nxd-header">
-  <% info = Header.new.items %>
   <header id="header" class="Nxd-header__main">
     <div class="Nxd-logo">
       <a href="/" id="logo" class="Nxd-logo__image Vlt-M-plus">
-        <%= image_tag info[:logo_path], alt: info[:logo_alt] %>
+        <%= image_tag header.logo_path, alt: header.logo_alt %>
 
         <hr class="Nxd-product__separator">
         <div class="Nxd-product__title Vlt-black">
-          <h4><%= info[:name] %></h4>
-          <small><%= info[:subtitle] %></small>
+          <h4><%= header.name %></h4>
+          <small><%= header.subtitle %></small>
         </div>
       </a>
       <a href="/" id="logo" class="Nxd-logo__image Vlt-S-only">
-        <%= image_tag info[:logo_path], alt: info[:logo_alt] %>
+        <%= image_tag header.small_logo_path, alt: header.logo_alt %>
       </a>
-      <% if info[:show_hiring_link] == true %>
+      <% if header.hiring_link? %>
         <a href=<%= careers_path %> class="Vlt-M-plus Vlt-badge Vlt-badge--purple Vlt-badge--transparent Vlt-badge--small Nxd-product__hiring">
           <span id="header-hiring"><%= t('.hiring') %></span>
         </a>
@@ -26,11 +26,12 @@
     <nav class="Nxd-header__nav">
       <a class="Nxd-main-header__link Vlt-M-plus Vlt-black" href="https://vonage.com/communications-apis">Vonage.com</a>
       <%= render partial: 'layouts/partials/locale_switcher' %>
-      <a href=<%= info[:sign_up_path] %> class="Vlt-btn Vlt-btn--secondary Vlt-btn--app" data-ab="try_button_v2"><b>
-          <% ab_test(:try_button_v2, info[:sign_up_text_arr].map { |s| ["{ #{s} }", "< #{s} />"] }.flatten) do |s| %>
+      <a href=<%= header.sign_up_path %> class="Vlt-btn Vlt-btn--secondary Vlt-btn--app" data-ab="try_button_v2"><b>
+          <% ab_test(:try_button_v2, header.sign_up_text.map { |s| ["{ #{s} }", "< #{s} />"] }.flatten) do |s| %>
             <%= t(".#{s}") %>
           <% end %>
-        </b></a>
+        </b>
+      </a>
     </nav>
   </header>
 

--- a/lib/nexmo_developer/app/webpacker/stylesheets/layout/_header.scss
+++ b/lib/nexmo_developer/app/webpacker/stylesheets/layout/_header.scss
@@ -171,6 +171,9 @@
     }
 
     .Vlt-dropdown__link__icon {
+      @media only screen and (max-width: 320px) {
+        display: none;
+      }
       margin-top: -4px;
     }
   }

--- a/lib/nexmo_developer/app/webpacker/stylesheets/layout/_header.scss
+++ b/lib/nexmo_developer/app/webpacker/stylesheets/layout/_header.scss
@@ -102,7 +102,7 @@
   }
 
   @media #{$S-only} {
-    text-align: right
+    text-align: right;
   }
 }
 
@@ -158,8 +158,17 @@
 }
 
 #locale-switcher {
+  margin-right: 24px;
+
+  @media only screen and (max-width: 320px) {
+    margin-right: 0px;
+  }
+
   .Vlt-btn {
-    margin-right: 24px;
+    @media #{$S-only} {
+      width: 100%;
+      padding: 1px 6px;
+    }
 
     .Vlt-dropdown__link__icon {
       margin-top: -4px;

--- a/lib/nexmo_developer/app/webpacker/stylesheets/objects/_card.scss
+++ b/lib/nexmo_developer/app/webpacker/stylesheets/objects/_card.scss
@@ -1,5 +1,7 @@
 .Nxd-card--products {
-  min-width: 300px;
+  @media not #{$S-only} {
+    min-width: 300px;
+  }
   height: 91%;
 
   nav a {

--- a/lib/nexmo_developer/spec/fixtures/config/business_info.yml
+++ b/lib/nexmo_developer/spec/fixtures/config/business_info.yml
@@ -3,6 +3,7 @@ subtitle: Sample Subtitle
 assets:
   header_logo:
     path: '/images/logos/sample-logo.png'
+    small_path: '/images/logos/Vonage-lettermark.svg'
     alt: 'Sample Alt'
   footer_logo:
     path: '/images/logos/Vonage-wordmark--white.svg'


### PR DESCRIPTION
## Description

Improves the way the header looks on smaller screens, it hides the `globe` icon for iphone SE/5 because it might not fit depending on the content of the `signup` button
![Screenshot 2020-07-15 at 15 38 03](https://user-images.githubusercontent.com/715229/87552114-86b8f200-c6b1-11ea-8ee9-030e130222ad.png)
![Screenshot 2020-07-14 at 13 48 53](https://user-images.githubusercontent.com/715229/87552118-87ea1f00-c6b1-11ea-9fed-6def81614a6c.png)
![Screenshot 2020-07-15 at 15 40 13](https://user-images.githubusercontent.com/715229/87552101-84ef2e80-c6b1-11ea-95f9-c49745e53ecd.png)
![Screenshot 2020-07-15 at 15 40 08](https://user-images.githubusercontent.com/715229/87552103-8587c500-c6b1-11ea-9517-77f4c423da8c.png)
![Screenshot 2020-07-15 at 15 40 00](https://user-images.githubusercontent.com/715229/87552106-8587c500-c6b1-11ea-8497-4d0791faa806.png)
![Screenshot 2020-07-15 at 15 38 31](https://user-images.githubusercontent.com/715229/87552108-86205b80-c6b1-11ea-8ee6-28baa2172262.png)
![Screenshot 2020-07-15 at 15 38 24](https://user-images.githubusercontent.com/715229/87552109-86205b80-c6b1-11ea-9f1a-25560db4b71b.png)
![Screenshot 2020-07-15 at 15 38 18](https://user-images.githubusercontent.com/715229/87552112-86b8f200-c6b1-11ea-8f52-09772f2738a7.png)
![Screenshot 2020-07-15 at 15 38 12](https://user-images.githubusercontent.com/715229/87552113-86b8f200-c6b1-11ea-9e65-97989e3ad81e.png)







![Screenshot 2020-07-15 at 15 40 18](https://user-images.githubusercontent.com/715229/87552098-84569800-c6b1-11ea-9486-6c8c1d733fe2.png)

