### PR TITLE
Bump OAS renderer version

### DIFF
--- a/lib/nexmo_developer/Gemfile
+++ b/lib/nexmo_developer/Gemfile
@@ -129,7 +129,7 @@ gem 'lograge'
 gem 'countries'
 gem 'country_select', '~> 4.0'
 
-gem 'nexmo-oas-renderer', github: 'nexmo/nexmo-oas-renderer', branch: 'ndp-gemification', require: false
+gem 'nexmo-oas-renderer', '~> 2.1', require: false
 
 gem 'nexmo_markdown_renderer', github: 'nexmo/nexmo-markdown-renderer', branch: 'consider-rails-root-for-views'
 

--- a/lib/nexmo_developer/Gemfile.lock
+++ b/lib/nexmo_developer/Gemfile.lock
@@ -13,25 +13,6 @@ GIT
       rouge (~> 2.0.7)
 
 GIT
-  remote: https://github.com/nexmo/nexmo-oas-renderer.git
-  revision: f81ee989314ce1a3001a0290cf7aeb2d82eaf72d
-  branch: ndp-gemification
-  specs:
-    nexmo-oas-renderer (2.0.1)
-      activemodel (~> 6.0)
-      activesupport (~> 6.0)
-      banzai (~> 0.1.2)
-      dotenv (~> 2.7)
-      neatjson (~> 0.8)
-      nexmo_markdown_renderer (~> 0.3)
-      oas_parser (~> 0.25.1)
-      octicons_helper (~> 8.2)
-      redcarpet (= 3.4.0)
-      sass (~> 3.1)
-      shotgun (~> 0.9)
-      sinatra (~> 2.0)
-
-GIT
   remote: https://github.com/oscardelben/rawler.git
   revision: f2909b135fce7d35167f98026ac481926c94423e
   specs:
@@ -321,6 +302,19 @@ GEM
     nenv (0.3.0)
     netrc (0.11.0)
     newrelic_rpm (6.12.0.367)
+    nexmo-oas-renderer (2.1.0)
+      activemodel (~> 6.0)
+      activesupport (~> 6.0)
+      banzai (~> 0.1.2)
+      dotenv (~> 2.7)
+      neatjson (~> 0.8)
+      nexmo_markdown_renderer (~> 0.3)
+      oas_parser (~> 0.25.1)
+      octicons_helper (~> 8.2)
+      redcarpet (= 3.4.0)
+      sass (~> 3.1)
+      shotgun (~> 0.9)
+      sinatra (~> 2.0)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -589,7 +583,7 @@ DEPENDENCIES
   lograge
   neatjson
   newrelic_rpm
-  nexmo-oas-renderer!
+  nexmo-oas-renderer (~> 2.1)
   nexmo_markdown_renderer!
   nokogiri (~> 1.10.9)
   octokit

--- a/nexmo_developer.gemspec
+++ b/nexmo_developer.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('activeadmin', '~> 2.7')
   spec.add_runtime_dependency('rails', '~> 6.0')
   spec.add_runtime_dependency('bootsnap', '~> 1.4')
-  spec.add_runtime_dependency('nexmo-oas-renderer', '~> 2.0')
+  spec.add_runtime_dependency('nexmo-oas-renderer', '~> 2.1')
   spec.add_runtime_dependency('nexmo_markdown_renderer', '~> 0.3')
   spec.add_runtime_dependency('activesupport', '~> 6.0')
   spec.add_runtime_dependency('bugsnag', '~> 6.13')


### PR DESCRIPTION
## Description

OAS renderer contains:

* Banner when content type is not supported e.g. text/xml
* Min/max support for strings and arrays
* Scoped JS to just the OAS pages

## Deploy Notes

N/A