### PR TITLE
[DEVX-3608] Add custom description tag

### DIFF
--- a/lib/nexmo_developer/app/presenters/head.rb
+++ b/lib/nexmo_developer/app/presenters/head.rb
@@ -1,66 +1,96 @@
 class Head
-  attr_reader :items
+  class Description
+    def initialize(config:, frontmatter:)
+      @config      = config
+      @frontmatter = frontmatter
+    end
 
-  def initialize(items: nil)
-    @items = items
+    def description
+      @description ||= from_frontmatter || @config.fetch('description') do
+        raise "You must provide a 'description' parameter in header_meta.yml"
+      end
+    end
+
+    def from_frontmatter
+      @frontmatter && (@frontmatter['meta_description'] || @frontmatter['description'])
+    end
+  end
+
+  attr_reader :config, :frontmatter
+
+  def initialize(frontmatter = nil)
+    @frontmatter = frontmatter
 
     after_initialize!
+    validate_files_presence!
   end
 
-  def head_from_config(config)
-    config = YAML.safe_load(open_config(config))
-    {
-      title: title(config),
-      description: description(config),
-      google_site_verification: config['google-site-verification'] || '',
-      application_name: config['application-name'],
-      og_image: file(config['og-image']),
-      og_image_width: config['og-image-width'],
-      og_image_height: config['og-image-height'],
-      apple_touch_icon: file('apple-touch-icon.png'),
-      favicon: file('favicon.ico'),
-      favicon_32_squared: file('favicon-32x32.png'),
-      manifest: file('manifest.json'),
-      safari_pinned_tab: file('safari-pinned-tab.svg'),
-      mstile_144_squared: file('mstile-144x144.png'),
-    }
+  def title
+    @title ||= config.fetch('title') do
+      raise "You must provide a 'title' parameter in header_meta.yml"
+    end
   end
 
-  def open_config(config)
-    File.open(config)
+  def description
+    @description ||= Description.new(config: config, frontmatter: frontmatter).description
   end
 
-  def config_exist?(path)
-    File.exist?(path)
+  def google_site_verification
+    @google_site_verification ||= config['google-site-verification']
   end
 
-  def file_does_not_exist?(path)
-    !File.exist?(path)
+  def application_name
+    @application_name ||= config['application-name']
+  end
+
+  def favicon
+    'meta/favicon.ico'
+  end
+
+  def favicon_32_squared
+    'meta/favicon-32x32.png'
+  end
+
+  def manifest
+    'meta/manifest.json'
+  end
+
+  def safari_pinned_tab
+    'meta/safari-pinned-tab.svg'
+  end
+
+  def mstile_144_squared
+    'meta/mstile-144x144.png'
+  end
+
+  def apple_touch_icon
+    'meta/apple-touch-icon.png'
+  end
+
+  def og_image
+    @og_image ||= "meta/#{config['og-image']}"
+  end
+
+  def og_image_width
+    @og_image_width ||= config['og-image-width']
+  end
+
+  def og_image_height
+    @og_image_height ||= config['og-image-height']
   end
 
   private
 
   def after_initialize!
-    raise 'You must provide a config/header_meta.yml file in your documentation path.' unless config_exist?("#{Rails.configuration.docs_base_path}/config/header_meta.yml")
+    config_path = "#{Rails.configuration.docs_base_path}/config/header_meta.yml"
+    raise 'You must provide a config/header_meta.yml file in your documentation path.' unless File.exist?(config_path)
 
-    @items = head_from_config("#{Rails.configuration.docs_base_path}/config/header_meta.yml")
+    @config = YAML.safe_load(File.open(config_path))
   end
 
-  def title(config)
-    raise "You must provide a 'title' parameter in header_meta.yml" if config['title'].blank?
-
-    config['title']
-  end
-
-  def description(config)
-    raise "You must provide an 'description' parameter in header_meta.yml" if config['description'].blank?
-
-    config['description']
-  end
-
-  def file(file_name)
-    raise "You must provide an #{file_name} file inside the public/meta directory" if file_does_not_exist?("#{Rails.configuration.docs_base_path}/public/meta/#{file_name}")
-
-    "meta/#{file_name}"
+  def validate_files_presence!
+    %i[favicon favicon_32_squared manifest safari_pinned_tab mstile_144_squared apple_touch_icon og_image].each do |file|
+      raise "You must provide an #{send(file).sub('meta/', '')} file inside the public/meta directory" unless File.exist?("#{Rails.configuration.docs_base_path}/public/#{send(file)}")
+    end
   end
 end

--- a/lib/nexmo_developer/app/presenters/head.rb
+++ b/lib/nexmo_developer/app/presenters/head.rb
@@ -90,7 +90,7 @@ class Head
 
   def validate_files_presence!
     %i[favicon favicon_32_squared manifest safari_pinned_tab mstile_144_squared apple_touch_icon og_image].each do |file|
-      raise "You must provide an #{send(file).sub('meta/', '')} file inside the public/meta directory" unless File.exist?("#{Rails.configuration.docs_base_path}/public/#{send(file)}")
+      raise "You must provide a #{send(file).sub('meta/', '')} file inside the public/meta directory" unless File.exist?("#{Rails.configuration.docs_base_path}/public/#{send(file)}")
     end
   end
 end

--- a/lib/nexmo_developer/app/views/layouts/partials/_head.html.erb
+++ b/lib/nexmo_developer/app/views/layouts/partials/_head.html.erb
@@ -1,15 +1,16 @@
+<% head = Head.new %>
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <% info = Head.new.items %>
 
-  <% if info[:google_site_verification] %>
-    <meta name="google-site-verification" content=<%= info[:google_site_verification] %> />
+  <% if head.google_site_verification %>
+    <meta name="google-site-verification" content=<%= head.google_site_verification %> />
   <% end %>
   <title><%= page_title %></title>
 
-  <% if @frontmatter && (@frontmatter['meta_description'] || @frontmatter['description']) %>
-    <meta name="description" content="<%= @frontmatter['meta_description'] || @frontmatter['description'] %>">
+  <% if head.description %>
+    <meta name="description" content="<%= head.description %>">
   <% end %>
 
   <%
@@ -94,23 +95,23 @@
     <meta name="robots" content="noindex,nofollow">
   <% end %>
 
-  <link rel="apple-touch-icon" sizes="180x180" href="<%= canonical_base %>/<%= info[:apple_touch_icon] %>">
-  <link rel="icon" type="image/png" sizes="any" href="<%= canonical_base %>/<%= info[:favicon] %>">
-  <link rel="icon" type="image/png" sizes="32x32" href="<%= canonical_base %>/<%= info[:favicon_32_squared] %>">
-  <link rel="manifest" href="<%= canonical_base %>/<%= info[:manifest] %>">
-  <link rel="mask-icon" href="<%= canonical_base %>/<%= info[:safari_pinned_tab] %>" color="#5bbad5">
-  <meta name="apple-mobile-web-app-title" content=<%= info[:title] %>>
-  <meta name="application-name" content=<%= info[:application_name] %>>
+  <link rel="apple-touch-icon" sizes="180x180" href="<%= canonical_base %>/<%= head.apple_touch_icon %>">
+  <link rel="icon" type="image/png" sizes="any" href="<%= canonical_base %>/<%= head.favicon %>">
+  <link rel="icon" type="image/png" sizes="32x32" href="<%= canonical_base %>/<%= head.favicon_32_squared %>">
+  <link rel="manifest" href="<%= canonical_base %>/<%= head.manifest %>">
+  <link rel="mask-icon" href="<%= canonical_base %>/<%= head.safari_pinned_tab %>" color="#5bbad5">
+  <meta name="apple-mobile-web-app-title" content=<%= head.title %>>
+  <meta name="application-name" content=<%= head.application_name %>>
   <meta name="msapplication-TileColor" content="#da532c">
-  <meta name="msapplication-TileImage" content="<%= canonical_base %>/<%= info[:mstile_144_squared] %>">
+  <meta name="msapplication-TileImage" content="<%= canonical_base %>/<%= head.mstile_144_squared %>">
   <meta name="theme-color" content="#ffffff">
 
   <meta property="og:url" content="<%= canonical_base + request.fullpath %>" />
   <meta property="og:type" content="article" />
-  <meta property="og:image" content="<%= canonical_base %>/<%= info[:og_image] %>" />
-  <meta property="og:image:width" content=<%= info[:og_image_width] %> />
-  <meta property="og:image:height" content=<%= info[:og_image_height] %> />
-  <meta property="og:description" content=<%= info[:description] %> />
+  <meta property="og:image" content="<%= canonical_base %>/<%= head.og_image %>" />
+  <meta property="og:image:width" content=<%= head.og_image_width %> />
+  <meta property="og:image:height" content=<%= head.og_image_height %> />
+  <meta property="og:description" content="<%= head.description %>"/>
   <meta name="twitter:card" content="summary_large_image" />
   <meta property="og:title" content="<%= page_title %>" />
 
@@ -130,7 +131,7 @@
     <% end %>
   <% end %>
 
-  <meta name="copyright" content="<%= Time.current.year %> <%= info[:application_name] %>" />
+  <meta name="copyright" content="<%= Time.current.year %> <%= head.application_name %>" />
 
   <%= csrf_meta_tags %>
 

--- a/lib/nexmo_developer/spec/presenters/head_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/head_spec.rb
@@ -1,58 +1,210 @@
 require 'rails_helper'
 
 RSpec.describe Head do
-  let(:items) { nil }
-  let(:path) { "#{Rails.configuration.docs_base_path}/config/header_meta.yml" }
-  let(:meta_base_path) { "#{Rails.configuration.docs_base_path}/public/meta" }
-  let(:config) do
-    {
-      'title' => 'Vonage',
-      'description' => 'A Description',
-      'google-site-verification' => '123456',
-      'application-name' => 'Vonage Business Cloud',
-    }
-  end
-  let(:yml) do
-    <<~HEREDOC
-      title: 'Vonage'
-      description: 'A Description'
-      google-site-verification: '123456'
-      application-name: 'Vonage Business Cloud'
-    HEREDOC
-  end
+  subject { described_class.new }
 
-  describe '#head_from_config with correct config' do
-    subject { described_class.new(items: items) }
+  before { allow(File).to receive(:exist?).and_call_original }
 
-    it 'returns an object with data from the config file' do
-      items = subject.items
+  describe '#initialize' do
+    it 'instantiates the presenter if the config file is present' do
+      expect { described_class.new }.not_to raise_error
+    end
 
-      expect(items).to eq(
-        {
-          title: 'Vonage API Developer',
-          description: 'A Description',
-          google_site_verification: '123456',
-          application_name: 'Vonage API Developer',
-          og_image: 'meta/nexmo-developer-card.png',
-          og_image_width: 835,
-          og_image_height: 437,
-          apple_touch_icon: 'meta/apple-touch-icon.png',
-          manifest: 'meta/manifest.json',
-          mstile_144_squared: 'meta/mstile-144x144.png',
-          safari_pinned_tab: 'meta/safari-pinned-tab.svg',
-          favicon: 'meta/favicon.ico',
-          favicon_32_squared: 'meta/favicon-32x32.png',
-        }
-      )
+    it 'raises if the config file is not present' do
+      allow(Rails.configuration).to receive(:docs_base_path).and_return('~/invalid_path/')
+      expect { described_class.new }
+        .to raise_error(RuntimeError, 'You must provide a config/header_meta.yml file in your documentation path.')
     end
   end
 
-  describe '#head_from_config with no config file' do
-    it 'raises an exception' do
-      allow_any_instance_of(described_class).to receive(:config_exist?).with(path).and_return(false)
-      allow_any_instance_of(described_class).to receive(:open_config).with(path).and_return(nil)
+  describe '#title' do
+    it { expect(subject.title).to eq('Vonage API Developer') }
 
-      expect { described_class.new }.to raise_error(RuntimeError, 'You must provide a config/header_meta.yml file in your documentation path.')
+    context 'when `title` is missing' do
+      before do
+        allow(YAML).to receive(:safe_load).and_return({})
+      end
+
+      it 'raises' do
+        expect { subject.title }
+          .to raise_error(RuntimeError, "You must provide a 'title' parameter in header_meta.yml")
+      end
     end
+  end
+
+  describe '#description' do
+    context 'without a frontmatter' do
+      it { expect(subject.description).to eq('A Description') }
+
+      context 'when `description` is missing' do
+        before do
+          allow(YAML).to receive(:safe_load).and_return({})
+        end
+
+        it 'raises' do
+          expect { subject.description }
+            .to raise_error(RuntimeError, "You must provide a 'description' parameter in header_meta.yml")
+        end
+      end
+    end
+
+    context 'a frontmatter takes precedence over the config file' do
+      subject { described_class.new(frontmatter) }
+
+      context 'with :meta_description' do
+        let(:frontmatter) do
+          { 'meta_description' => 'Meta description text' }
+        end
+
+        it { expect(subject.description).to eq('Meta description text') }
+      end
+
+      context 'with :description' do
+        let(:frontmatter) do
+          { 'description' => 'Description text' }
+        end
+
+        it { expect(subject.description).to eq('Description text') }
+      end
+
+      context 'with both' do
+        let(:frontmatter) do
+          {
+            'description' => 'Description text',
+            'meta_description' => 'Meta description text',
+          }
+        end
+
+        it { expect(subject.description).to eq('Meta description text') }
+      end
+    end
+  end
+
+  describe '#google_site_verification' do
+    it { expect(subject.google_site_verification).to eq('123456') }
+  end
+
+  describe '#application_name' do
+    it { expect(subject.application_name).to eq('Vonage API Developer') }
+  end
+
+  describe '#favicon' do
+    it { expect(subject.favicon).to eq('meta/favicon.ico') }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?)
+          .with("#{Rails.configuration.docs_base_path}/public/meta/favicon.ico").and_return(false)
+      end
+
+      it 'raises' do
+        expect { subject.favicon }
+          .to raise_error(RuntimeError, 'You must provide an favicon.ico file inside the public/meta directory')
+      end
+    end
+  end
+
+  describe '#favicon_32_squared' do
+    it { expect(subject.favicon_32_squared).to eq('meta/favicon-32x32.png') }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?)
+          .with("#{Rails.configuration.docs_base_path}/public/meta/favicon-32x32.png").and_return(false)
+      end
+
+      it 'raises' do
+        expect { subject.favicon_32_squared }
+          .to raise_error(RuntimeError, 'You must provide an favicon-32x32.png file inside the public/meta directory')
+      end
+    end
+  end
+
+  describe '#manifest' do
+    it { expect(subject.manifest).to eq('meta/manifest.json') }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?)
+          .with("#{Rails.configuration.docs_base_path}/public/meta/manifest.json").and_return(false)
+      end
+
+      it 'raises' do
+        expect { subject.manifest }
+          .to raise_error(RuntimeError, 'You must provide an manifest.json file inside the public/meta directory')
+      end
+    end
+  end
+
+  describe '#safari_pinned_tab' do
+    it { expect(subject.safari_pinned_tab).to eq('meta/safari-pinned-tab.svg') }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?)
+          .with("#{Rails.configuration.docs_base_path}/public/meta/safari-pinned-tab.svg").and_return(false)
+      end
+
+      it 'raises' do
+        expect { subject.safari_pinned_tab }
+          .to raise_error(RuntimeError, 'You must provide an safari-pinned-tab.svg file inside the public/meta directory')
+      end
+    end
+  end
+
+  describe '#mstile_144_squared' do
+    it { expect(subject.mstile_144_squared).to eq('meta/mstile-144x144.png') }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?)
+          .with("#{Rails.configuration.docs_base_path}/public/meta/mstile-144x144.png").and_return(false)
+      end
+
+      it 'raises' do
+        expect { subject.mstile_144_squared }
+          .to raise_error(RuntimeError, 'You must provide an mstile-144x144.png file inside the public/meta directory')
+      end
+    end
+  end
+
+  describe '#apple_touch_icon' do
+    it { expect(subject.apple_touch_icon).to eq('meta/apple-touch-icon.png') }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?)
+          .with("#{Rails.configuration.docs_base_path}/public/meta/apple-touch-icon.png").and_return(false)
+      end
+
+      it 'raises' do
+        expect { subject.apple_touch_icon }
+          .to raise_error(RuntimeError, 'You must provide an apple-touch-icon.png file inside the public/meta directory')
+      end
+    end
+  end
+
+  describe '#og_image' do
+    it { expect(subject.og_image).to eq('meta/nexmo-developer-card.png') }
+
+    context 'when the file is missing' do
+      before do
+        allow(File).to receive(:exist?)
+          .with("#{Rails.configuration.docs_base_path}/public/meta/nexmo-developer-card.png").and_return(false)
+      end
+
+      it 'raises' do
+        expect { subject.og_image }
+          .to raise_error(RuntimeError, 'You must provide an nexmo-developer-card.png file inside the public/meta directory')
+      end
+    end
+  end
+
+  describe '#og_image_width' do
+    it { expect(subject.og_image_width).to eq(835) }
+  end
+
+  describe '#og_image_height' do
+    it { expect(subject.og_image_height).to eq(437) }
   end
 end

--- a/lib/nexmo_developer/spec/presenters/head_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/head_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Head do
 
       it 'raises' do
         expect { subject.favicon }
-          .to raise_error(RuntimeError, 'You must provide an favicon.ico file inside the public/meta directory')
+          .to raise_error(RuntimeError, 'You must provide a favicon.ico file inside the public/meta directory')
       end
     end
   end
@@ -115,7 +115,7 @@ RSpec.describe Head do
 
       it 'raises' do
         expect { subject.favicon_32_squared }
-          .to raise_error(RuntimeError, 'You must provide an favicon-32x32.png file inside the public/meta directory')
+          .to raise_error(RuntimeError, 'You must provide a favicon-32x32.png file inside the public/meta directory')
       end
     end
   end
@@ -131,7 +131,7 @@ RSpec.describe Head do
 
       it 'raises' do
         expect { subject.manifest }
-          .to raise_error(RuntimeError, 'You must provide an manifest.json file inside the public/meta directory')
+          .to raise_error(RuntimeError, 'You must provide a manifest.json file inside the public/meta directory')
       end
     end
   end
@@ -147,7 +147,7 @@ RSpec.describe Head do
 
       it 'raises' do
         expect { subject.safari_pinned_tab }
-          .to raise_error(RuntimeError, 'You must provide an safari-pinned-tab.svg file inside the public/meta directory')
+          .to raise_error(RuntimeError, 'You must provide a safari-pinned-tab.svg file inside the public/meta directory')
       end
     end
   end
@@ -163,7 +163,7 @@ RSpec.describe Head do
 
       it 'raises' do
         expect { subject.mstile_144_squared }
-          .to raise_error(RuntimeError, 'You must provide an mstile-144x144.png file inside the public/meta directory')
+          .to raise_error(RuntimeError, 'You must provide a mstile-144x144.png file inside the public/meta directory')
       end
     end
   end
@@ -179,7 +179,7 @@ RSpec.describe Head do
 
       it 'raises' do
         expect { subject.apple_touch_icon }
-          .to raise_error(RuntimeError, 'You must provide an apple-touch-icon.png file inside the public/meta directory')
+          .to raise_error(RuntimeError, 'You must provide a apple-touch-icon.png file inside the public/meta directory')
       end
     end
   end
@@ -195,7 +195,7 @@ RSpec.describe Head do
 
       it 'raises' do
         expect { subject.og_image }
-          .to raise_error(RuntimeError, 'You must provide an nexmo-developer-card.png file inside the public/meta directory')
+          .to raise_error(RuntimeError, 'You must provide a nexmo-developer-card.png file inside the public/meta directory')
       end
     end
   end

--- a/lib/nexmo_developer/spec/views/layouts/partials/_head.html.erb_spec.rb
+++ b/lib/nexmo_developer/spec/views/layouts/partials/_head.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'head', type: :view do
+  before do
+    without_partial_double_verification do
+      allow(view).to receive(:page_title).and_return('Title')
+    end
+  end
+
+  subject { render partial: '/layouts/partials/head.html.erb' }
+
+  describe "<meta name='description'" do
+    it 'renders the meta_description' do
+      expect(Capybara::Node::Simple.new(subject))
+        .to have_css('meta[name="description"][content="A Description"]', visible: false)
+    end
+  end
+end


### PR DESCRIPTION
## Description

The `<meta description>` and `<og:description>` tags will now use the same value.
If a `frontmatter` is present, the content will be the value of `@frontmatter['meta_description]` or `@frontmatter['description']` providing the correct value for all the docs and custom pages.

For the landing page, `@frontmatter` is not defined, and in that case, the value comes from `config/header_meta.yml` 