### PR TITLE
Use `yarn install --frozen-lockfile` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN bundle install --without development:test:assets -j4 --retry 3 --path=vendor
     && find vendor/bundle/ruby/2.5.0/gems/ -name "*.o" -delete
 
 # Install node dependencies
-RUN yarn install --production
+RUN yarn install --frozen-lockfile
 
 # Copy the app in to /station and compile assets
 COPY lib/nexmo_developer/ $RAILS_ROOT/


### PR DESCRIPTION
## Description

Use `yarn install --frozen-lockfile` in Dockerfile  instead of `--production`.

Some of the packages listed in DevDependencies are needed for
precompiling the assets and we also want to ensure that yarn.lock is not
updated.

