### PR TITLE
Docs Subfolder

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,0 +1,34 @@
+# Contents
+
+1. [Dependencies](#dependencies)
+2. [Booting Up For the First Time](#booting-up-for-the-first-time)
+
+## Dependencies
+
+Station is a platform tool built with Ruby on Rails. All of its attendant dependencies are managed internally and require only itself to be included as a dependency for installation.
+
+Either within the top-level folder of the content to be served or in a separate folder structure create a `Gemfile` and include the following in it:
+
+```ruby
+source "https://rubygems.pkg.github.com/nexmo" do
+  gem "nexmo-developer"
+end
+```
+
+Station is hosted on the GitHub Package registry, and requires its own credentials to be added to your system to download the package from it. The GitHub Package Registry documentation includes [step-by-step instructions](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-rubygems-for-use-with-github-packages) on setting up your system to authenticate to the registry if it is the first time downloading a package from the registry.
+
+Once the `Gemfile` is completed, Station can be downloaded and installed locally by executing `bundle install` from the command line. 
+
+## Booting Up For The First Time
+
+Station requires a certain defined file structure in the content file path provided to the CLI when booting it up. Please refer to the [Configuration](https://github.com/Nexmo/station/wiki/Configuration) page for detailed instructions. Without this file structure, Station will not run correctly.
+
+To start Station the following command can be executed from the command line, replacing `/content/path` with the absolute file path to your content:
+
+```bash
+$ bundle exec nexmo-developer --docs=/content/path
+```
+
+For troubleshooting diagnosis you can turn on logging output to the console by prepending `RAILS_LOG_TO_STDOUT=true` to the command. This can also be defined permanently in a dotenv file in the top-level folder of your content.
+
+Station is also available as a Docker image. Please refer to the [How To Use](https://github.com/Nexmo/station/wiki/How-To-Use) page for instructions on booting it up with Docker.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -21,7 +21,7 @@ Once the `Gemfile` is completed, Station can be downloaded and installed locally
 
 ## Booting Up For The First Time
 
-Station requires a certain defined file structure in the content file path provided to the CLI when booting it up. Please refer to the [Configuration](https://github.com/Nexmo/station/blob/master/docs/Configuration) page for detailed instructions. Without this file structure, Station will not run correctly.
+Station requires a certain defined file structure in the content file path provided to the CLI when booting it up. Please refer to the [How To Use](https://github.com/Nexmo/station/blob/master/docs/How-To-Use#configuration-files) page for detailed instructions. Without this file structure, Station will not run correctly.
 
 To start Station the following command can be executed from the command line, replacing `/content/path` with the absolute file path to your content:
 
@@ -31,4 +31,4 @@ $ bundle exec nexmo-developer --docs=/content/path
 
 For troubleshooting diagnosis you can turn on logging output to the console by prepending `RAILS_LOG_TO_STDOUT=true` to the command. This can also be defined permanently in a dotenv file in the top-level folder of your content.
 
-Station is also available as a Docker image. Please refer to the [How To Use](https://github.com/Nexmo/station/blob/master/docs/How-To-Use) page for instructions on booting it up with Docker.
+Station is also available as a Docker image. Please refer to the [How To Use](https://github.com/Nexmo/station/blob/master/docs/How-To-Use#running-with-docker) page for instructions on booting it up with Docker.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -21,7 +21,7 @@ Once the `Gemfile` is completed, Station can be downloaded and installed locally
 
 ## Booting Up For The First Time
 
-Station requires a certain defined file structure in the content file path provided to the CLI when booting it up. Please refer to the [Configuration](https://github.com/Nexmo/station/wiki/Configuration) page for detailed instructions. Without this file structure, Station will not run correctly.
+Station requires a certain defined file structure in the content file path provided to the CLI when booting it up. Please refer to the [Configuration](https://github.com/Nexmo/station/blob/master/docs/Configuration) page for detailed instructions. Without this file structure, Station will not run correctly.
 
 To start Station the following command can be executed from the command line, replacing `/content/path` with the absolute file path to your content:
 
@@ -31,4 +31,4 @@ $ bundle exec nexmo-developer --docs=/content/path
 
 For troubleshooting diagnosis you can turn on logging output to the console by prepending `RAILS_LOG_TO_STDOUT=true` to the command. This can also be defined permanently in a dotenv file in the top-level folder of your content.
 
-Station is also available as a Docker image. Please refer to the [How To Use](https://github.com/Nexmo/station/wiki/How-To-Use) page for instructions on booting it up with Docker.
+Station is also available as a Docker image. Please refer to the [How To Use](https://github.com/Nexmo/station/blob/master/docs/How-To-Use) page for instructions on booting it up with Docker.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,41 @@
+# Station
+
+1. [What Is Station?](#what-is-station)
+2. [What Is Station For?](#what-is-station-for)
+3. [What Problems Does Station Solve?](#what-problems-does-station-solve)
+4. [How Does Station Accomplish Its Goals?](#how-does-station-accomplish-its-goals)
+
+## What Is Station?
+
+Station is a platform tool. In combination with custom configuration files and a path to content files in markdown, Station provides a platform website that can be used for any number of purposes.
+
+Station is built with Ruby on Rails as its infrastructure incorporated with Webpack. For the experienced Rails developer, it will feel familiar. For a person not acquainted with Rails, it will be unnecessary to learn the nuances of the framework to run or contribute content to a Station powered site. 
+
+## What Is Station For?
+
+Station is built to provide the following out of the box:
+
+* A solution for creating text-driven content websites quickly
+* The ability for non-software developers to contribute content in a streamlined fashion
+* Highly customizable to meet each site's needs through a set of defined configuration files
+
+## What Problems Does Station Solve?
+
+There are multiple concerns involved in creating a platform site, and all too often, any individual contributor needs to be proficient in many of them to make a contribution in their area of expertise. A technical writer should not need to know Ruby to offer documentation. A graphic designer should not need to know JavaScript to contribute a graphic design for the site. Yet, in many instances, that is the case.
+
+Furthermore, a single business often can have multiple product lines that need multiple documentation or developer portals. It can be difficult to ensure that the style guide and overall look of the business remain consistent over time across different platform sites. 
+
+Station comes to solve both of these problems. Through Station people can contribute in their area of expertise without needing to be proficient in other areas. Likewise, through Station distinct product documentation portals under the same business can be built and can retain sustainably the same experience across platforms.
+
+## How Does Station Accomplish Its Goals?
+
+Station accomplishes this by:
+
+* Providing a CLI that lets administrators boot up a platform with a one-line command
+* Offering different configuration files for different customizable aspects of the platform
+* Integrating web assets such as images from the `/public` folder in the content path into the platform
+* Utilizing custom exception messaging to provide users with advice during troubleshooting platform problems
+* Disaggregating the code of the platform and its content so content contributors do not need to be concerned at all with the code
+* With regular releases of new versions following semantic versioning guidelines, providing administrators with the assurance that their platform will be current with dependency upgrades by maintaining a single gem dependency, that of Station itself
+
+Learn more about [Getting Started](https://github.com/Nexmo/station/wiki/Getting-Started) and [How To Use](https://github.com/Nexmo/station/wiki/How-To-Use) Station.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -38,4 +38,4 @@ Station accomplishes this by:
 * Disaggregating the code of the platform and its content so content contributors do not need to be concerned at all with the code
 * With regular releases of new versions following semantic versioning guidelines, providing administrators with the assurance that their platform will be current with dependency upgrades by maintaining a single gem dependency, that of Station itself
 
-Learn more about [Getting Started](https://github.com/Nexmo/station/wiki/Getting-Started) and [How To Use](https://github.com/Nexmo/station/wiki/How-To-Use) Station.
+Learn more about [Getting Started](https://github.com/Nexmo/station/blob/master/docs/Getting-Started) and [How To Use](https://github.com/Nexmo/station/blob/master/docs/How-To-Use) Station.

--- a/docs/How-To-Use.md
+++ b/docs/How-To-Use.md
@@ -1,0 +1,147 @@
+# Contents
+
+1. [Content Structure and Files](#content-structure-and-files)
+    1. [File Organization](#file-organization)
+    2. [Configuration Files](#configuration-files)
+    3. [Customization Options](#customization-options)
+2. [Running Station](#running-station)
+    1. [Running Standalone](#running-standalone)
+    2. [Running With Docker](#running-with-docker)
+
+## Content Structure and Files
+
+Station requires the content served by the platform to be organized in a defined way. The platform will not start if the folder structure is not present in the content path provided during initialization.
+
+Additionally, Station offers a lot of opportunities to customize the platform for unique needs.
+
+This section will go through each of these areas.
+
+### File Organization
+
+Inside the top-level folder of the content there must be the following folders:
+
+```
++-- _use_cases
++-- _documentation
++-- _tutorials
++-- public
++-- config
+```
+
+If you wish to include API specification reference documents you should also include a `_open_api` folder in the top-level of your folder structure as well.
+
+### Configuration Files
+
+All configuration files are written in YAML. The [Official YAML Web Site](https://yaml.org/) provides instructions on YAML formatting and specifications.
+
+There are [same configuration files](https://github.com/Nexmo/station/blob/master/sample_config_files/config) provided in this repository that can be used to provide a template for the configuration files for your instance of Station.
+
+All configuration files are placed inside the `/config` folder.
+
+The files required are:
+
+* `business_info.yml`: Specific business/organizational information for the platform. This includes the platform name, the path to the header and footer logos, and more.
+* `top_navigation.yml`: The links for the top navigation bar of the platform. 
+* `meta_info.yml`: Information used to generate the links in the platform's `<head>` tags, such as search engine optimization details.
+* `products.yml`: A list of each product or item covered in the platform's content. The icon, documentation path and color schema for each product is also specified here.
+
+In addition to the above configuration files, Station also expects the following files to be created and placed inside the `/public/meta` path. These files are meta icons also used in the generation of the `<head>` content:
+
+* `og.png`
+* `apple-touch-icon.png`
+* `safari-pinned-tab.svg`
+* `mstile-144x144.png`
+* `favicon.ico`
+* `favicon-32x32.png`
+* `manifest.json`
+
+Specific credentials and identification information for different third-party services can be included in the platform by placing them inside a dotenv file in the top-leve folder of the content. There is a [sample .env file](https://github.com/Nexmo/station/blob/master/.env.example) provided in this repository.
+
+### Customization Options
+
+Station provides many opportunities to customize the presentation of the platform. This section will walk through each possibility.
+
+#### Custom Views
+
+Custom views can be provided that override the defaults in Station. A sample [custom views folder](https://github.com/Nexmo/station/blob/master/sample_config_files/custom/views) can be found in this repository.
+
+To provide your own custom view for a Station view place it inside `/custom/views`.
+
+The file should be an ERB file. ERB, or embedded Ruby, are HTML files that combine Ruby to product dynamic content. The [Ruby documentation](https://docs.ruby-lang.org/en/2.3.0/ERB.html) provides detailed instructions on how to write with ERB.
+
+#### Custom Landing Pages
+
+Landing Pages are a feature of Station that enables content creators to introduce unique website pages using only YAML to create the content.
+
+A [sample landing pages folder](https://github.com/Nexmo/station/blob/master/sample_config_files/custom/landing_pages) has been provided in this repository to offer examples.
+
+All landing pages should be placed inside `/custom/landing_pages`. The URL path is defined by the file path. For example, a file placed inside `/custom/landing_pages/events/myevent.yml` would be viewed in the browser at `https://example.com/events/myevent`.
+
+Detailed instructions are available in the [Contribution Guide](https://developer.nexmo.com/contribute/guides/landing-pages) on creating landing pages.
+
+#### Custom Public Path
+
+Custom assets, such as images and icons, can be provided in the `/public` folder. They then can be referenced inside custom views. For example, if the following image is added inside `/public/assets/media/logos/sample_image.png` then it could be referenced using ERB syntax as follows:
+
+```ruby
+<%= image_tag('/assets/media/logos/sample_image.png') %>
+```
+
+#### Custom Locale Settings
+
+Station supports internationalization for different spoken languages. Content translations can be provided inside the `/custom/locales` folder. A [sample locales folder](https://github.com/Nexmo/station/blob/master/sample_config_files/config/locales) has been provided inside Station with examples of locale configuration files.
+
+## Running Station
+
+Station can be run either standalone on your system or in Docker with the provided Docker image. 
+
+### Running Standalone
+
+Once you have installed Station and ran through the configurations, you can start it.
+
+To start the gem run the following from the command line:
+
+```bash
+$ OAS_PATH=[PATH TO _open_api folder] bundle exec nexmo-developer --docs=[PATH TO DOCUMENTATION]
+```
+
+For example, if your documentation is at `/Users/sample_user/Documents/sample_docs` and your `_open_api folder` is at `/Users/sample_user/Documents/sample_docs/_open_api` then you would start nexmo-developer with the following command:
+
+```bash
+$ OAS_PATH=/Users/sample_user/Documents/sample_docs/_open_api
+```
+
+The `OAS_PATH` environment variable passed in during runtime can also be provided in the dotenv file mentioned above in the instructions.
+
+### Running With Docker
+
+Station is available as a Docker image at `nemxodev/station`. You can run it from your documentation directory using the following command:
+
+```bash
+docker run -p 3000:3000 -v /path/to/docs:/docs -t nexmodev/station
+```
+
+Any functionality requiring a database (such as redirects or feedback) will not work using this method. For a docker-based setup that includes a database add the following `docker-compose.yml` file to your project:
+
+```
+version: "3"
+services:
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_USER=nexmo_developer
+      - POSTGRES_DB=nexmo_developer_production
+  web:
+    image: nexmodev/station:latest
+    volumes:
+      - .:/docs
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      - POSTGRES_HOST=db
+```
+
+After running `docker-compose up`, you will need to run `docker-compose run web bundle exec rake db:migrate` to initialise the database.


### PR DESCRIPTION
## Description

Move the current docs in the GitHub Wiki to a `/docs` subfolder
