### PR TITLE
Skip spotlight spec.

### DIFF
--- a/lib/nexmo_developer/spec/features/spotlight_spec.rb
+++ b/lib/nexmo_developer/spec/features/spotlight_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Spotlight', ndp: true, js: true do
     allow(RestClient).to receive(:post).and_return(double(code: 200))
   end
 
-  scenario 'submitting an idea' do
+  xscenario 'submitting an idea' do
     visit '/spotlight'
 
     fill_in 'Your Name', with: 'John'


### PR DESCRIPTION

## Description

Github Action OS was updated and it now includes Chrome 85 which does
not work with the headless browsers, making the spec to fail.
