### PR TITLE
Bump serialize-javascript version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "kind-of": "^6.0.3",
     "jpeg-js": "^0.4.0",
     "http-proxy": "^1.18.1",
-    "serialize-javascript": "^4.0.0",
+    "serialize-javascript": "^5.0.1",
     "url-regex": "^5.0.0",
     "marked": "^0.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11559,14 +11559,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.4.0, serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^5.0.1:
+serialize-javascript@^1.4.0, serialize-javascript@^4.0.0, serialize-javascript@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
   integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==


### PR DESCRIPTION
## Description

Running `yarn install --frozen-lockfile` was failing with `Your lockfile
needs to be updated, but yarn was run with --frozen-lockfile`, but
running `yarn install` didn't update `yarn.lock`.

The issue was that `serialize-javascript` was listed twice in
`package.json`, under `dependencies` and `resolutions` with different
versions.

