### PR TITLE
Allowing station to pull stars/forks from multiple orgs

### DIFF
--- a/lib/nexmo_developer/app/views/static/default_landing/partials/_github_repo.html.erb
+++ b/lib/nexmo_developer/app/views/static/default_landing/partials/_github_repo.html.erb
@@ -4,7 +4,7 @@
     raise "Missing 'language' key in github_repo landing page block" unless local_assigns['language']
 %>
 
-    <a class="Vlt-card Nxd-github-card Vlt-left" href="<%= local_assigns['repo_url'] %>" data-github="<%= local_assigns['repo_url'].split('github.com/').last %>">
+    <a class="Vlt-card Nxd-github-card Vlt-left" href="<%= local_assigns['repo_url'] %>" data-github="<%= local_assigns['repo_url'].split('.com/').last %>">
       <h3 class="Vlt-blue-dark"><%= local_assigns['repo_url'].split('/').last %></h3>
       <p><%= local_assigns['github_repo_title'] %></p>
       <% if local_assigns['badge_url'] %>

--- a/lib/nexmo_developer/app/views/static/default_landing/partials/_github_repo.html.erb
+++ b/lib/nexmo_developer/app/views/static/default_landing/partials/_github_repo.html.erb
@@ -4,7 +4,7 @@
     raise "Missing 'language' key in github_repo landing page block" unless local_assigns['language']
 %>
 
-    <a class="Vlt-card Nxd-github-card Vlt-left" href="<%= local_assigns['repo_url'] %>" data-github="Nexmo/<%= local_assigns['repo_url'].split('/').last %>">
+    <a class="Vlt-card Nxd-github-card Vlt-left" href="<%= local_assigns['repo_url'] %>" data-github="<%= local_assigns['repo_url'].split('github.com/').last %>">
       <h3 class="Vlt-blue-dark"><%= local_assigns['repo_url'].split('/').last %></h3>
       <p><%= local_assigns['github_repo_title'] %></p>
       <% if local_assigns['badge_url'] %>

--- a/lib/nexmo_developer/spec/views/static/default_landing/partials/_github_repo.html.erb_spec.rb
+++ b/lib/nexmo_developer/spec/views/static/default_landing/partials/_github_repo.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'rendering _github_repo landing page partial' do
         'language' => 'Ruby',
     }
 
-    expect(rendered).to include('<a class="Vlt-card Nxd-github-card Vlt-left" href="https://example.com/org/repo-name" data-github="Nexmo/repo-name">')
+    expect(rendered).to include('<a class="Vlt-card Nxd-github-card Vlt-left" href="https://example.com/org/repo-name" data-github="org/repo-name">')
     expect(rendered).to include('<h3 class="Vlt-blue-dark">repo-name</h3>')
     expect(rendered).to include('<p>This is a sample title</p>')
     expect(rendered).to include('<span class="Vlt-blue-dark">●</span> Ruby')


### PR DESCRIPTION
## Description

The [tools page](https://developer.nexmo.com/tools) for ADP isn't able to pull stars/forks from non-nexmo organizations. This is because of the way the URL is formed to interact with the GitHub API. Currently, it splits on the last `/` and automatically pre-pends `Nexmo/` to the front of the URL.