### PR TITLE
Add vue alias so that it includes the template compiler.

### DIFF
--- a/lib/nexmo_developer/config/webpack/custom.js
+++ b/lib/nexmo_developer/config/webpack/custom.js
@@ -1,0 +1,7 @@
+module.exports = {
+  resolve: {
+    alias: {
+      vue: 'vue/dist/vue.js',
+    }
+  }
+}

--- a/lib/nexmo_developer/config/webpack/environment.js
+++ b/lib/nexmo_developer/config/webpack/environment.js
@@ -3,10 +3,14 @@ const { environment } = require('@rails/webpacker')
 const { VueLoaderPlugin } = require('vue-loader')
 const vue = require('./loaders/vue')
 const ManifestPlugin = require('webpack-manifest-plugin')
+const customConfig = require('./custom')
 
 const babelLoader = environment.loaders.get('babel')
 babelLoader.exclude = []
 environment.splitChunks()
+
+// Merge custom config
+environment.config.merge(customConfig)
 
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 environment.loaders.prepend('vue', vue)


### PR DESCRIPTION
## Description

Fixes vue, in version 0.0.91 we changed Vue's version, and it didn't include the template compiler. Hence, the components weren't being rendered
