### PR TITLE
Fixes collapsed `header` in OAS ref pages on Safari.

### DIFF
--- a/lib/nexmo_developer/app/webpacker/stylesheets/layout/_api.scss
+++ b/lib/nexmo_developer/app/webpacker/stylesheets/layout/_api.scss
@@ -163,4 +163,5 @@
 
 .oas-page .Nxd-header {
   position: static;
+  flex-shrink: 0;
 }


### PR DESCRIPTION
## Description

It is not calculating the heights properly, hence the header was
collapsed.

Example: https://developer.nexmo.com/api/conversation?theme=dark

![Screenshot 2020-11-12 at 09 54 51](https://user-images.githubusercontent.com/715229/98951271-51ef6700-24fa-11eb-9e72-8a2ff36e3f61.png)
