### PR TITLE
DEVX-3436: Increment Markdown Renderer in Station

### DIFF
--- a/lib/nexmo_developer/Gemfile
+++ b/lib/nexmo_developer/Gemfile
@@ -131,7 +131,7 @@ gem 'country_select', '~> 4.0'
 
 gem 'nexmo-oas-renderer', '~> 2.4.1', require: false
 
-gem 'nexmo_markdown_renderer', '~> 0.6'
+gem 'nexmo_markdown_renderer', '~> 0.7'
 
 gem 'smartling'
 

--- a/lib/nexmo_developer/Gemfile.lock
+++ b/lib/nexmo_developer/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.7.0)
+    loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.2.8)
@@ -308,7 +308,7 @@ GEM
       sass (~> 3.1)
       shotgun (~> 0.9)
       sinatra (~> 2.0)
-    nexmo_markdown_renderer (0.6.0)
+    nexmo_markdown_renderer (0.7.0)
       activemodel (~> 6.0)
       banzai (~> 0.1.2)
       i18n (~> 1.7)
@@ -590,7 +590,7 @@ DEPENDENCIES
   neatjson
   newrelic_rpm
   nexmo-oas-renderer (~> 2.4.1)
-  nexmo_markdown_renderer (~> 0.6)
+  nexmo_markdown_renderer (~> 0.7)
   nokogiri (~> 1.10.9)
   octokit
   pg (~> 1.2)

--- a/station.gemspec
+++ b/station.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('rails', '~> 6.0')
   spec.add_runtime_dependency('bootsnap', '~> 1.4')
   spec.add_runtime_dependency('nexmo-oas-renderer', '~> 2.4')
-  spec.add_runtime_dependency('nexmo_markdown_renderer', '~> 0.6')
+  spec.add_runtime_dependency('nexmo_markdown_renderer', '~> 0.7')
   spec.add_runtime_dependency('activesupport', '~> 6.0')
   spec.add_runtime_dependency('bugsnag', '~> 6.13')
   spec.add_runtime_dependency('railties', '~> 6.0')


### PR DESCRIPTION
## Description

This bumps up the version of `nexmo-markdown-renderer` in Station to incorporate the latest release that adds the copy to clipboard functionality as described in DEVX-3436.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
