### PR TITLE
Bump Markdown Renderer

### DIFF
--- a/lib/nexmo_developer/Gemfile
+++ b/lib/nexmo_developer/Gemfile
@@ -131,7 +131,7 @@ gem 'country_select', '~> 4.0'
 
 gem 'nexmo-oas-renderer', '~> 2.4.1', require: false
 
-gem 'nexmo_markdown_renderer', '~> 0.7'
+gem 'nexmo_markdown_renderer', '~> 0.7.1'
 
 gem 'smartling'
 

--- a/lib/nexmo_developer/Gemfile.lock
+++ b/lib/nexmo_developer/Gemfile.lock
@@ -592,7 +592,7 @@ DEPENDENCIES
   neatjson
   newrelic_rpm
   nexmo-oas-renderer (~> 2.4.1)
-  nexmo_markdown_renderer (~> 0.7)
+  nexmo_markdown_renderer (~> 0.7.1)
   nokogiri (~> 1.10.9)
   octokit
   pg (~> 1.2)

--- a/lib/nexmo_developer/version.rb
+++ b/lib/nexmo_developer/version.rb
@@ -1,3 +1,3 @@
 module NexmoDeveloper
-  VERSION = '0.0.103'.freeze
+  VERSION = '0.0.104'.freeze
 end

--- a/station.gemspec
+++ b/station.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('rails', '~> 6.0')
   spec.add_runtime_dependency('bootsnap', '~> 1.4')
   spec.add_runtime_dependency('nexmo-oas-renderer', '~> 2.4')
-  spec.add_runtime_dependency('nexmo_markdown_renderer', '~> 0.7')
+  spec.add_runtime_dependency('nexmo_markdown_renderer', '~> 0.7.1')
   spec.add_runtime_dependency('activesupport', '~> 6.0')
   spec.add_runtime_dependency('bugsnag', '~> 6.13')
   spec.add_runtime_dependency('railties', '~> 6.0')


### PR DESCRIPTION
## Description

Bump markdown renderer to 0.7.1 for `snippet_variables` bug fix. Also bumps the version as I'll release straight after merge

## Deploy Notes

N/A