### PR TITLE
Add Engine support

### DIFF
--- a/lib/nexmo_developer/app/services/load_config.rb
+++ b/lib/nexmo_developer/app/services/load_config.rb
@@ -11,4 +11,8 @@ class LoadConfig
       YAML.load_file("#{Rails.root}/#{file_path}")
     end
   end
+
+  def self.exist?(file_path)
+    File.exist?("#{docs_base_path}/#{file_path}") || File.exist?("#{Rails.root}/#{file_path}")
+  end
 end

--- a/lib/nexmo_developer/config/routes.rb
+++ b/lib/nexmo_developer/config/routes.rb
@@ -102,6 +102,13 @@ Rails.application.routes.draw do
 
   get '/ed', to: 'static#blog_cookie'
 
+  if LoadConfig.exist?('config/engines.yml')
+    engines = LoadConfig.load_file('config/engines.yml')
+    engines.each do |path, klass|
+      mount klass.constantize, at: path
+    end
+  end
+
   get '*unmatched_route', to: 'application#not_found'
 
   root 'static#landing'


### PR DESCRIPTION
## Description

This PR enables Station consumers to extend the platform with their own controllers by defining `config/engines.yml` to be loaded

```yaml
---
/auth: NexmoAuth::Engine
```

This allows us to write code and package it up as a gem for a specific instance of Station. In this example, it is some non-Open Source code related to "Login with Nexmo"

No engines are added in this PR as they would be registered in the `nexmo-developer` Gemfile and config

## Deploy Notes

N/A