### PR TITLE
Pass auth to Markdown Pipeline

### DIFF
--- a/lib/nexmo_developer/app/controllers/markdown_controller.rb
+++ b/lib/nexmo_developer/app/controllers/markdown_controller.rb
@@ -118,6 +118,8 @@ class MarkdownController < ApplicationController
       code_language: @code_language,
       current_user: current_user,
       locale: params[:locale],
+      api_key: cookies.encrypted['api_key'],
+      api_secret: cookies.encrypted['api_secret'],
     }).call(content)
 
     [frontmatter, content]


### PR DESCRIPTION
## Description

Pass the API key and secret from cookies in to the markdown pipeline. If they do not exist the provided value is nil

## Deploy Notes

N/A