### PR TITLE
Fix scrolling on pages with tabs.

### DIFF
--- a/lib/nexmo_developer/app/webpacker/javascript/volta/volta.js
+++ b/lib/nexmo_developer/app/webpacker/javascript/volta/volta.js
@@ -1455,7 +1455,7 @@ Volta.tab = function () {
 
 			this._activeLink.setAttribute('tabindex', '0');
 			this._activeLink.setAttribute('aria-selected', 'true');
-			this._activeLink.focus();
+                        this._activeLink.focus({ preventScroll: true });
 			if (this._activePanel) {
 				this._activePanel.removeAttribute('hidden');
 			}


### PR DESCRIPTION
## Description

The auto-scrolling happened because the focus was set on the tab
-either the default one or the one stored in the user's preferences-.
This change prevents the scrolling from happening while keeping the
focus working.
