### PR TITLE
Improve this page link when path is not in docs repo

### DIFF
--- a/lib/nexmo_developer/app/presenters/improve_page_presenter.rb
+++ b/lib/nexmo_developer/app/presenters/improve_page_presenter.rb
@@ -9,7 +9,7 @@ class ImprovePagePresenter
 
   def docs_repo
     @docs_repo ||= begin
-      path_to_url.include?('app/') ? 'nexmo/station' : YAML.safe_load(File.open("#{Rails.configuration.docs_base_path}/config/business_info.yml"))['docs_repo']
+      path_to_url.start_with?('app/') ? 'nexmo/station' : YAML.safe_load(File.open("#{Rails.configuration.docs_base_path}/config/business_info.yml"))['docs_repo']
     end
   end
 

--- a/lib/nexmo_developer/app/presenters/improve_page_presenter.rb
+++ b/lib/nexmo_developer/app/presenters/improve_page_presenter.rb
@@ -7,13 +7,15 @@ class ImprovePagePresenter
     @github_url ||= "https://github.com/#{docs_repo}/blob/#{ENV.fetch('branch', 'master')}/#{path_to_url}"
   end
 
+  def docs_repo
+    @docs_repo ||= begin
+      path_to_url.include?('app/') ? 'nexmo/station' : YAML.safe_load(File.open("#{Rails.configuration.docs_base_path}/config/business_info.yml"))['docs_repo']
+    end
+  end
+
   private
 
   def path_to_url
     @document_path&.gsub("#{Rails.configuration.docs_base_path}/", '')
-  end
-
-  def docs_repo
-    @docs_repo ||= YAML.safe_load(File.open("#{Rails.configuration.docs_base_path}/config/business_info.yml"))['docs_repo']
   end
 end

--- a/lib/nexmo_developer/app/presenters/improve_page_presenter.rb
+++ b/lib/nexmo_developer/app/presenters/improve_page_presenter.rb
@@ -9,13 +9,12 @@ class ImprovePagePresenter
 
   def docs_repo
     @docs_repo ||= begin
-      path_to_url.start_with?('app/') ? 'nexmo/station' : YAML.safe_load(File.open("#{Rails.configuration.docs_base_path}/config/business_info.yml"))['docs_repo']
+      path_to_url.start_with?('lib/nexmo_developer/app/') ? 'nexmo/station' : YAML.safe_load(File.open("#{Rails.configuration.docs_base_path}/config/business_info.yml"))['docs_repo']
     end
   end
 
-  private
-
   def path_to_url
-    @document_path&.gsub("#{Rails.configuration.docs_base_path}/", '')
+    @document_path&.gsub!("#{Rails.configuration.docs_base_path}/", '')
+    @document_path.start_with?('app/') ? @document_path.prepend('lib/nexmo_developer/') : @document_path
   end
 end

--- a/lib/nexmo_developer/app/views/contribute/guides/markdown-guide.md
+++ b/lib/nexmo_developer/app/views/contribute/guides/markdown-guide.md
@@ -126,6 +126,16 @@ They auto-magically color when you use verbs like [POST] or [DELETE]
 |
 | Nullam id dolor id nibh ultricies vehicula ut id elit. Donec ullamcorper nulla non metus auctor fringilla. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
 
+````
+| ### Click me
+|
+| Here is some hidden content.
+|
+| Markdown _still_ works `here`!
+|
+| Nullam id dolor id nibh ultricies vehicula ut id elit. Donec ullamcorper nulla non metus auctor fringilla. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+````
+
 | ### Alpha
 |
 | Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec id elit non mi porta gravida at eget metus. Sed posuere consectetur est at lobortis. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla.
@@ -134,13 +144,31 @@ They auto-magically color when you use verbs like [POST] or [DELETE]
 |
 | Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec id elit non mi porta gravida at eget metus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Aenean lacinia bibendum nulla sed consectetur. Nullam quis risus eget urna mollis ornare vel eu leo.
 
+````
+| ### Alpha
+|
+| Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec id elit non mi porta gravida at eget metus. Sed posuere consectetur est at lobortis. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla.
+|
+| Donec id elit non mi porta gravida at eget metus. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Nulla vitae elit libero, a pharetra augue. Donec sed odio dui. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Cras mattis consectetur purus sit amet fermentum.
+|
+| Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Donec id elit non mi porta gravida at eget metus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Aenean lacinia bibendum nulla sed consectetur. Nullam quis risus eget urna mollis ornare vel eu leo.
+````
+
 **Tooltips (custom plugin)**
 
 Find out ^[more](Tooltips are useful for when you have more information to convey, but don't want to break context.).
 
+````
+Find out ^[more](Tooltips are useful for when you have more information to convey, but don't want to break context.).
+````
+
 ## Images
 
 ![Please always add alt-text](https://media.giphy.com/media/pDTLSpqNvNxlu/giphy.gif)
+
+````
+![Please always add alt-text](https://media.giphy.com/media/pDTLSpqNvNxlu/giphy.gif)
+````
 
 > Images should be used sparingly, try to avoid using screenshots that might go out of date.
 >
@@ -183,14 +211,20 @@ See our detailed [code examples guide](/contribute/guides/code-examples) for adv
 ## Tables
 
 > Pipes should only be between cells. Two hyphens `--` should be used to 'underline' the headings.
->
-> You'll have to view the `markdown-guide.md` source to see how since showing you the syntax would result in it being processed.
 
 | Key          | Description                                                                                |
 | ------------ | ------------------------------------------------------------------------------------------ |
 | `TO_NUMBER`  | The number you are sending the SMS to                                                      |
 | `API_KEY`    | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview) |
 | `API_SECRET` | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview) |
+
+````
+| Key          | Description                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| `TO_NUMBER`  | The number you are sending the SMS to                                                      |
+| `API_KEY`    | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview) |
+| `API_SECRET` | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview) |
+````
 
 ## Tabbed Content (custom plugin)
 

--- a/lib/nexmo_developer/spec/presenters/improve_page_presenter_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/improve_page_presenter_spec.rb
@@ -23,8 +23,16 @@ RSpec.describe ImprovePagePresenter do
     end
 
     context 'when the path to the doc is outside Station' do
-      it 'returns the Station repository' do
+      it 'returns the docs repository' do
         expect(subject.docs_repo).to eq('nexmo/nexmo-developer')
+      end
+    end
+
+    context 'when the path is outside Station but includes characters that might match a path in Station' do
+      let(:document_path) { '_documentation/en/app-to-phone/overview.md' }
+
+      it 'still returns the docs repository' do
+        expect(described_class.new(document_path).docs_repo).to eq('nexmo/nexmo-developer')
       end
     end
   end

--- a/lib/nexmo_developer/spec/presenters/improve_page_presenter_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/improve_page_presenter_spec.rb
@@ -12,4 +12,20 @@ RSpec.describe ImprovePagePresenter do
       expect(subject.github_url).to eq('https://github.com/nexmo/nexmo-developer/blob/master/_documentation/en/concepts/overview.md')
     end
   end
+
+  describe '#docs_repo' do
+    context 'when the path to the doc is in Station' do
+      let(:document_path) { 'app/views/contribute/overview.md' }
+
+      it 'returns the Station repository' do
+        expect(described_class.new(document_path).docs_repo).to eq('nexmo/station')
+      end
+    end
+
+    context 'when the path to the doc is outside Station' do
+      it 'returns the Station repository' do
+        expect(subject.docs_repo).to eq('nexmo/nexmo-developer')
+      end
+    end
+  end
 end

--- a/lib/nexmo_developer/spec/presenters/improve_page_presenter_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/improve_page_presenter_spec.rb
@@ -36,4 +36,20 @@ RSpec.describe ImprovePagePresenter do
       end
     end
   end
+
+  describe '#path_to_url' do
+    context 'with a path to a doc in Station' do
+      let(:document_path) { 'app/views/contribute/overview.md' }
+
+      it 'returns a proper Station path' do
+        expect(described_class.new(document_path).path_to_url).to eq('lib/nexmo_developer/app/views/contribute/overview.md')
+      end
+    end
+
+    context 'with a path to a doc in a docs portal repository' do
+      it 'returns a path not modified for Station' do
+        expect(subject.path_to_url).to eq('_documentation/en/concepts/overview.md')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

The `improve this page` link doesn't resolve to the correct path when the doc in reference is actually in Station, since the URL is created by using the `docs_base_path`. This PR checks for that and uses the correct repository depending on where the path is coming from.