### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Fetch NDP
       uses: actions/checkout@master
       with:
-        ref: master
+        ref: main
         repository: nexmo/nexmo-developer
         token: ${{ secrets.GITHUB_TOKEN }}
         path: ndp


### PR DESCRIPTION
## Description

The CI is broken on the `fetch NDP` step because it's pointing to `master` and needs to point to `main`
