### PR TITLE
Allow landing pages to set `title` and `description` tags.

### DIFF
--- a/lib/nexmo_developer/app/controllers/static_controller.rb
+++ b/lib/nexmo_developer/app/controllers/static_controller.rb
@@ -45,6 +45,8 @@ class StaticController < ApplicationController
       migrate_tropo
     end
 
+    @frontmatter = @landing_config
+    @document_title = @landing_config['title']
     @navigation = yaml_name.to_sym
     render layout: 'landing'
   end

--- a/lib/nexmo_developer/app/presenters/head.rb
+++ b/lib/nexmo_developer/app/presenters/head.rb
@@ -26,9 +26,13 @@ class Head
   end
 
   def title
-    @title ||= config.fetch('title') do
+    @title ||= title_from_frontmatter || config.fetch('title') do
       raise "You must provide a 'title' parameter in header_meta.yml"
     end
+  end
+
+  def title_from_frontmatter
+    @frontmatter && (@frontmatter['meta_title'] || @frontmatter['title'])
   end
 
   def description


### PR DESCRIPTION
## Description

Allow landing pages to set the title, `title` and `description` tags.

