### PR TITLE
add notifier to Orbit Vonage workspace for new Feedback

### DIFF
--- a/docs/How-To-Use.md
+++ b/docs/How-To-Use.md
@@ -269,4 +269,6 @@ Any step can capture the user's email address so that you can get back to them a
 
 The feedback captured by the wizard is stored in the database at `[YOUR_SITE_URL]/admin/feedbacks`. The questions the user was asked and the responses they entered are also stored, so that the users' answers can be seen in the context of the questions you asked. So, if you change the wizard's configuration, the users' responses still make sense.
 
+### Integration with Orbit
 
+Feedback can be sent to your organization's [Orbit](https://www.orbit.love) workspace by configuring two environment variables: `ORBIT_API_KEY` and `ORBIT_WORKSPACE_ID`. The feedback sentiment (e.g. negative, positive), documentation resource URI and visitor email address is sent to the Orbit workspace for any feedback left by a visitor that provides an email address.

--- a/lib/nexmo_developer/app/models/feedback/feedback.rb
+++ b/lib/nexmo_developer/app/models/feedback/feedback.rb
@@ -26,7 +26,7 @@ module Feedback
     end
 
     def notify
-      OrbitFeedbackNotifier.call(self) unless self.owner.nil?
+      OrbitFeedbackNotifier.call(self) unless owner.nil?
 
       return unless ENV['SLACK_WEBHOOK']
 

--- a/lib/nexmo_developer/app/models/feedback/feedback.rb
+++ b/lib/nexmo_developer/app/models/feedback/feedback.rb
@@ -26,7 +26,7 @@ module Feedback
     end
 
     def notify
-      OrbitFeedbackNotifier.call(self) unless owner.nil?
+      OrbitFeedbackNotifier.call(self) if !owner.nil? && owner.email.present?
 
       return unless ENV['SLACK_WEBHOOK']
 

--- a/lib/nexmo_developer/app/models/feedback/feedback.rb
+++ b/lib/nexmo_developer/app/models/feedback/feedback.rb
@@ -26,6 +26,8 @@ module Feedback
     end
 
     def notify
+      OrbitFeedbackNotifier.call(self) unless self.owner.nil?
+
       return unless ENV['SLACK_WEBHOOK']
 
       FeedbackSlackNotifier.call(self)

--- a/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
+++ b/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
@@ -22,6 +22,8 @@ class OrbitFeedbackNotifier
   end
 
   def post!
+    return unless ENV['ORBIT_WORKSPACE_ID']
+
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     req = Net::HTTP::Post.new(uri)

--- a/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
+++ b/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
@@ -32,6 +32,11 @@ class OrbitFeedbackNotifier
         activity_type: 'adp:feedback',
         key: "adp-new-feedback-#{params[:email]}-#{Time.zone.now}",
       },
+      'identity' => {
+        'source' => 'ADP',
+        'source_host' => 'https://developer.vonage.com',
+        'email' => params[:email],
+      },
     }
     req
   end

--- a/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
+++ b/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
@@ -1,0 +1,38 @@
+class OrbitFeedbackNotifier
+  def self.call(feedback)
+    new(feedback).post!
+  end
+
+  def initialize(feedback)
+    @feedback = feedback
+  end
+
+  def params
+    @params ||= {
+      email: @feedback.owner.email,
+      resource: "Offered #{@feedback.sentiment} feedback on #{@feedback.resource.uri}",
+    }
+  end
+
+  def orbit_uri
+    URI("https://app.orbit.love/api/v1/#{ENV['ORBIT_WORKSPACE_ID']}/activities")
+  end
+
+  def post!
+    http = Net::HTTP.new(orbit_uri.host, orbit_uri.port)
+    http.use_ssl = true
+    req = Net::HTTP::Post.new(orbit_uri.path, {
+      'Content-Type' => 'application/json',
+      'Authorization' => "Bearer #{ENV['ORBIT_API_KEY']}",
+    })
+    req.body = {
+      'activity' => {
+        title: 'Offered feedback on ADP',
+        description: params[:resource],
+        activity_type: 'adp:feedback',
+        key: "adp-new-feedback-#{params[:email]}-#{Time.zone.now}",
+      },
+    }
+    req
+  end
+end

--- a/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
+++ b/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
@@ -1,4 +1,6 @@
 class OrbitFeedbackNotifier
+  CONFIG = YAML.load_file("#{Rails.configuration.docs_base_path}/config/business_info.yml")
+
   def self.call(feedback)
     new(feedback).post!
   end
@@ -37,7 +39,7 @@ class OrbitFeedbackNotifier
       },
       identity: {
         source: 'email',
-        source_host: 'https://developer.vonage.com',
+        source_host: CONFIG['base_url'],
         email: params[:email],
       },
     }

--- a/lib/nexmo_developer/spec/controllers/feedback/feedbacks_controller_spec.rb
+++ b/lib/nexmo_developer/spec/controllers/feedback/feedbacks_controller_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Feedback::FeedbacksController, type: :controller do
       end
 
       it 'creates a author with an email' do
+        expect(OrbitFeedbackNotifier).to receive(:call)
+
         post :create, xhr: true, params: {
           feedback_feedback: {
             sentiment: 'positive',
@@ -44,6 +46,8 @@ RSpec.describe Feedback::FeedbacksController, type: :controller do
         end
 
         it 'reuses the author' do
+          expect(OrbitFeedbackNotifier).to receive(:call)
+
           post :create, xhr: true, params: {
             feedback_feedback: {
               sentiment: 'positive',
@@ -65,6 +69,8 @@ RSpec.describe Feedback::FeedbacksController, type: :controller do
       end
 
       it 'reuses the author' do
+        expect(OrbitFeedbackNotifier).to receive(:call)
+
         post :create, xhr: true, params: {
           feedback_feedback: {
             sentiment: 'positive',
@@ -78,6 +84,8 @@ RSpec.describe Feedback::FeedbacksController, type: :controller do
 
       context 'but the email does not match' do
         it 'creates a new author' do
+          expect(OrbitFeedbackNotifier).to receive(:call)
+
           post :create, xhr: true, params: {
             feedback_feedback: {
               sentiment: 'positive',
@@ -101,6 +109,8 @@ RSpec.describe Feedback::FeedbacksController, type: :controller do
       end
 
       it 'reuses the user' do
+        expect(OrbitFeedbackNotifier).to receive(:call)
+
         post :create, xhr: true, params: {
           feedback_feedback: {
             sentiment: 'positive',
@@ -116,6 +126,8 @@ RSpec.describe Feedback::FeedbacksController, type: :controller do
 
       context 'and an email is provided' do
         it 'ignores the email' do
+          expect(OrbitFeedbackNotifier).to receive(:call)
+
           post :create, xhr: true, params: {
             feedback_feedback: {
               sentiment: 'positive',
@@ -132,6 +144,8 @@ RSpec.describe Feedback::FeedbacksController, type: :controller do
 
     context 'when a feedback already exists' do
       before do
+        expect(OrbitFeedbackNotifier).to receive(:call)
+
         @feedback = FactoryBot.create(:feedback_feedback, sentiment: 'positive')
       end
 

--- a/lib/nexmo_developer/spec/models/feedback/feedback_spec.rb
+++ b/lib/nexmo_developer/spec/models/feedback/feedback_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Feedback::Feedback, type: :model do
       let(:end_date) { nil }
 
       it 'excludes feedbacks created before start_date' do
+        expect(OrbitFeedbackNotifier).to receive(:call)
+
         FactoryBot.create(:feedback_feedback, created_at: date - 1)
 
         feedbacks = described_class.created_between(start_date, end_date)
@@ -22,6 +24,8 @@ RSpec.describe Feedback::Feedback, type: :model do
       let(:end_date) { date }
 
       it 'excludes feedbacks created after end_date' do
+        expect(OrbitFeedbackNotifier).to receive(:call)
+
         FactoryBot.create(:feedback_feedback, created_at: date + 1)
 
         feedbacks = described_class.created_between(start_date, end_date)

--- a/lib/nexmo_developer/spec/models/feedback/feedback_spec.rb
+++ b/lib/nexmo_developer/spec/models/feedback/feedback_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe Feedback::Feedback, type: :model do
       end
     end
 
+    context 'when there is an owner email defined' do
+      it 'fires an Orbit notification' do
+        author = Feedback::Author.new(email: 'devrel@vonage.com')
+        subject.owner = author
+
+        expect(OrbitFeedbackNotifier).to receive(:call).with(subject)
+
+        subject.notify
+      end
+    end
+
     context 'otherwise' do
       it { expect(subject.notify).to eq(nil) }
     end

--- a/lib/nexmo_developer/spec/services/orbit_feedback_notifier_spec.rb
+++ b/lib/nexmo_developer/spec/services/orbit_feedback_notifier_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe OrbitFeedbackNotifier do
-  let(:workspace_id) { 'abc123' }
-  let(:uri) { "https://app.orbit.love/api/v1/#{workspace_id}/activities" }
+  let(:uri) { 'https://app.orbit.love/api/v1/test-workspace/activities' }
   let(:config_file) { "#{Rails.configuration.docs_base_path}/config/feedback.yml" }
   let!(:config) { Feedback::Config.find_or_create_config(YAML.safe_load(File.read(config_file))) }
   let!(:feedback) do
@@ -10,7 +9,9 @@ RSpec.describe OrbitFeedbackNotifier do
       config: config,
       sentiment: 'positive',
       path: 0,
-      steps: ['nothing!']
+      steps: ['nothing!'],
+      owner: Feedback::Author.new(email: 'devrel@vonage.com'),
+      resource: Feedback::Resource.new(uri: 'https://example.com/docs')
     )
   end
 
@@ -19,13 +20,16 @@ RSpec.describe OrbitFeedbackNotifier do
   before do
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with('ORBIT_API_KEY').and_return('api_key')
+    allow(ENV).to receive(:[]).with('ORBIT_WORKSPACE_ID').and_return('test-workspace')
   end
 
   describe '#post!' do
     it 'sends the new feedback to Orbit' do
       stub_request(:post, uri)
         .with(headers: { 'Authorization' => "Bearer #{ENV['ORBIT_API_KEY']}", 'Content-Type' => 'application/json' })
-        .to_return(status: 201)
+        .to_return(status: 200)
+
+      subject.post!
     end
   end
 end

--- a/lib/nexmo_developer/spec/services/orbit_feedback_notifier_spec.rb
+++ b/lib/nexmo_developer/spec/services/orbit_feedback_notifier_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe OrbitFeedbackNotifier do
+  let(:workspace_id) { 'abc123' }
+  let(:uri) { "https://app.orbit.love/api/v1/#{workspace_id}/activities" }
+  let(:config_file) { "#{Rails.configuration.docs_base_path}/config/feedback.yml" }
+  let!(:config) { Feedback::Config.find_or_create_config(YAML.safe_load(File.read(config_file))) }
+  let!(:feedback) do
+    Feedback::Feedback.new(
+      config: config,
+      sentiment: 'positive',
+      path: 0,
+      steps: ['nothing!']
+    )
+  end
+
+  subject { described_class.new(feedback) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('ORBIT_API_KEY').and_return('api_key')
+  end
+
+  describe '#post!' do
+    it 'sends the new feedback to Orbit' do
+      stub_request(:post, uri)
+        .with(headers: { 'Authorization' => "Bearer #{ENV['ORBIT_API_KEY']}", 'Content-Type' => 'application/json' })
+        .to_return(status: 201)
+    end
+  end
+end

--- a/lib/nexmo_developer/spec/views/admin/feedbacks/_steps.html.erb_spec.rb
+++ b/lib/nexmo_developer/spec/views/admin/feedbacks/_steps.html.erb_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'admin/feedbacks/_steps.html.erb' do
   end
 
   it 'renders the corresponding specs' do
+    expect(OrbitFeedbackNotifier).to receive(:call)
+
     render partial: 'admin/feedbacks/steps.html.erb', locals: { feedback: feedback }
 
     expect(rendered).to have_css('b', text: 'I need help with something else.')


### PR DESCRIPTION
## Description

When new feedback is created that has an author a new activity will be sent to the Vonage Orbit workspace

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
