### PR TITLE
remove source host from payload

### DIFF
--- a/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
+++ b/lib/nexmo_developer/app/services/orbit_feedback_notifier.rb
@@ -1,6 +1,4 @@
 class OrbitFeedbackNotifier
-  CONFIG = YAML.load_file("#{Rails.configuration.docs_base_path}/config/business_info.yml")
-
   def self.call(feedback)
     new(feedback).post!
   end
@@ -41,7 +39,6 @@ class OrbitFeedbackNotifier
       },
       identity: {
         source: 'email',
-        source_host: CONFIG['base_url'],
         email: params[:email],
       },
     }


### PR DESCRIPTION
## Description

Conferred with @phazonoverload and the `source_host` key is not required in the payload, only email is needed.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
