### PR TITLE
Break long one-line code-snippets into multiple lines.

### DIFF
--- a/lib/nexmo_developer/app/webpacker/stylesheets/custom/_core.scss
+++ b/lib/nexmo_developer/app/webpacker/stylesheets/custom/_core.scss
@@ -194,3 +194,7 @@ table {
 code .token.function{
   color: #E75B2F !important;
 }
+
+pre.Vlt-prism--dark code {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Description

Some one-line code-snippets are too long to be display in one line forcing the users to scroll [e.g.](https://developer.nexmo.com/client-sdk/tutorials/app-to-app/client-sdk/app-to-app/create-webhook-server/javascript)
This break them into multiple lines.
