### PR TITLE
Change tutorial links

### DIFF
--- a/lib/nexmo_developer/app/views/tutorial/list.html.erb
+++ b/lib/nexmo_developer/app/views/tutorial/list.html.erb
@@ -49,7 +49,7 @@
                 <hr class="hr--short"></hr>
 
                 <% tutorial.available_languages.each do |language| %>
-                  <a href="<%= url_for(controller: :tutorial, action: :list, product: @product, code_language: language.label.downcase, only_path: true) %>">
+                  <a href="<%= tutorial.url %>/<%= language.language.downcase %>">
                     <small class="Vlt-grey-darker Nxd-tutorials__language Nxd-tutorials__language--<%= language.language %>"><span>●</span> <%= language.label %></small>
                   </a>
                 <% end %>


### PR DESCRIPTION
## Description

Make programming language labels in the tutorial cards point to the actual tutorial in the selected language.

