### PR TITLE
Use utm params instead of a cookie when redirecting to dashboard.

### DIFF
--- a/lib/nexmo_developer/app/controllers/static_controller.rb
+++ b/lib/nexmo_developer/app/controllers/static_controller.rb
@@ -149,22 +149,17 @@ class StaticController < ApplicationController
   end
 
   def blog_cookie
-    # This is the first touch time so we only want to set it if it's not already set
-    set_utm_cookie('ft', Time.now.getutc.to_i) unless cookies[:ft]
-
-    # Clear out old values that might not be set
-    cookies.delete('utm_campaign', domain: :all)
-    cookies.delete('utm_term', domain: :all)
-    cookies.delete('utm_content', domain: :all)
-
     # These are the things we'll be tracking through the customer dashboard
-    set_utm_cookie('utm_medium', 'dev_education')
-    set_utm_cookie('utm_source', 'blog')
-    set_utm_cookie('utm_campaign', params['c']) if params['c']
-    set_utm_cookie('utm_content', params['ct']) if params['ct']
-    set_utm_cookie('utm_term', params['t']) if params['t']
+    utm_params = {
+      'utm_medium' => 'dev_education',
+      'utm_source' => 'blog',
+    }
 
-    redirect_to 'https://dashboard.nexmo.com/sign-up'
+    utm_params.merge!('utm_campaign' => params['c']) if params['c']
+    utm_params.merge!('utm_content'  => params['ct']) if params['ct']
+    utm_params.merge!('utm_term'     => params['t']) if params['t']
+
+    redirect_to "https://dashboard.nexmo.com/sign-up?#{utm_params.to_query}"
   end
 
   private

--- a/lib/nexmo_developer/spec/controllers/static_controller_spec.rb
+++ b/lib/nexmo_developer/spec/controllers/static_controller_spec.rb
@@ -307,4 +307,20 @@ RSpec.describe StaticController, type: :request do
       it_behaves_like 'renders the corresponding layout', [['Vlt-col--1of2', 'Vlt-col--1of2']]
     end
   end
+
+  describe '#ed' do
+    it 'redirects to the dashboard' do
+      get '/ed'
+
+      expect(response).to redirect_to('https://dashboard.nexmo.com/sign-up?utm_medium=dev_education&utm_source=blog')
+    end
+
+    context 'with extra params' do
+      it 'redirects to the dashboard' do
+        get '/ed', params: { 'c' => 'campaign', 'ct' => 'content', 't' => 'term' }
+
+        expect(response).to redirect_to('https://dashboard.nexmo.com/sign-up?utm_campaign=campaign&utm_content=content&utm_medium=dev_education&utm_source=blog&utm_term=term')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

The /ed route was used for signup tracking from the blog and
learn.vonage. Given that ADP and the dashboard shared domains, using a
cookie worked, but now that we are changing ADP's domain, this approach
no longer works. So now, we use utm params for this

