### PR TITLE
FIX: updated version of readingtime (= 0.4.0) + bump station version

### DIFF
--- a/lib/nexmo_developer/Gemfile
+++ b/lib/nexmo_developer/Gemfile
@@ -96,7 +96,7 @@ gem 'bootsnap', require: false
 gem 'diffy', require: false
 
 # Provides estimated reading times (for our Blog)
-gem 'readingtime'
+gem 'readingtime', '0.4.0'
 
 gem 'addressable', '~> 2.8', require: false
 

--- a/lib/nexmo_developer/Gemfile.lock
+++ b/lib/nexmo_developer/Gemfile.lock
@@ -667,7 +667,7 @@ DEPENDENCIES
   rails (~> 6.1.4)
   rails-controller-testing
   rawler!
-  readingtime
+  readingtime (= 0.4.0)
   recaptcha
   redis
   rest-client

--- a/lib/nexmo_developer/app/helpers/blog_helper.rb
+++ b/lib/nexmo_developer/app/helpers/blog_helper.rb
@@ -1,7 +1,9 @@
 module BlogHelper
-  def readind_time_without_code_tags(content)
+  def reading_time_without_code_tags(content)
     regexp = Regexp.new(%r{<pre class=.*main-code(.*?)</code></pre>}m)
 
     "#{content.gsub(regexp, '').reading_time format: :approx} read"
+  rescue StandardError
+    ''
   end
 end

--- a/lib/nexmo_developer/app/views/blog/blogpost/show.html.erb
+++ b/lib/nexmo_developer/app/views/blog/blogpost/show.html.erb
@@ -7,10 +7,13 @@
   <div style="display:flex;justify-content: space-between;">
     <div style="width:20%"></div>
     <div style="width:58%">
+
       <!-- Reading time -->
+      <% reading = reading_time_without_code_tags(@blogpost.content) %>
+      <% if reading.present? %>
       <div style="display:flex;justify-content: flex-end;">
         <p style="text-opacity: 1; color: rgba(107,114,128,.8); text-align: right;">
-          <%= readind_time_without_code_tags(@blogpost.content)%>&nbsp;
+          <%= reading %>&nbsp;
         </p>
         <p>
           <svg class="Vlt-icon Vlt-icon--smaller Vlt-grey-darker" style="opacity: .6;">
@@ -18,6 +21,8 @@
           </svg>
         </p>
       </div>
+      <% end %> <!-- Reading time -->
+
     </div>
     <div style="width:20%"></div>
   </div>

--- a/lib/nexmo_developer/version.rb
+++ b/lib/nexmo_developer/version.rb
@@ -1,3 +1,3 @@
 module NexmoDeveloper
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/station.gemspec
+++ b/station.gemspec
@@ -83,7 +83,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('sassc-rails', '2.1.2')
   spec.add_runtime_dependency('gmaps4rails', '2.1.2')
   spec.add_runtime_dependency('chartkick', '4.0.5')
-  spec.add_runtime_dependency('readingtime', '0.3.1')
+  spec.add_runtime_dependency('readingtime', '0.4.0')
 
   spec.add_development_dependency('rubocop', '~> 1.16.0')
   spec.add_development_dependency('rubocop-rails', '~> 2.6')


### PR DESCRIPTION
## Description

- Added fixed version (**0.4.0**) for `readingtime` gem
- Bumped station version to **v0.1.2**