### PR TITLE
FIX: addressable guard clause for thumbnail + bump Station Version v0…

### DIFF
--- a/lib/nexmo_developer/app/models/blog/blogpost.rb
+++ b/lib/nexmo_developer/app/models/blog/blogpost.rb
@@ -50,6 +50,8 @@ class Blog::Blogpost
     require 'net/http'
     require 'addressable'
 
+    return DEFAULT_VONAGE_LOGO_URL if @thumbnail.empty?
+
     @thumbnail = @thumbnail.gsub('/content/blog/') do |match| # gsub Netlify img urls
       "#{Blog::Blogpost::CLOUDFRONT_BLOG_URL}blogposts/#{match.gsub('/content/blog/', '')}"
     end

--- a/lib/nexmo_developer/version.rb
+++ b/lib/nexmo_developer/version.rb
@@ -1,3 +1,3 @@
 module NexmoDeveloper
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end


### PR DESCRIPTION
….1.5

## Description

`return DEFAULT_VONAGE_LOGO_URL if @thumbnail.empty?`
