### PR TITLE
Adding re-direct for whatsapp number hosting page

### DIFF
--- a/lib/nexmo_developer/config/redirects.yml
+++ b/lib/nexmo_developer/config/redirects.yml
@@ -278,3 +278,5 @@
 "/dispatch/tutorials/sending-facebook-message-with-failover": "/dispatch/tutorials/send-facebook-message-with-failover"
 "/task/sending-facebook-message-with-failover": "/dispatch/tutorials/send-facebook-message-with-failover"
 "/concepts/guides/webhook": "/concepts/guides/webhooks"
+"/concepts/guides/webhook": "/concepts/guides/webhooks"
+"/messages/concepts/whatsapp-hosting": "/messages/concepts/whatsapp#whatsapp-number-hosting"

--- a/lib/nexmo_developer/config/redirects.yml
+++ b/lib/nexmo_developer/config/redirects.yml
@@ -278,5 +278,4 @@
 "/dispatch/tutorials/sending-facebook-message-with-failover": "/dispatch/tutorials/send-facebook-message-with-failover"
 "/task/sending-facebook-message-with-failover": "/dispatch/tutorials/send-facebook-message-with-failover"
 "/concepts/guides/webhook": "/concepts/guides/webhooks"
-"/concepts/guides/webhook": "/concepts/guides/webhooks"
 "/messages/concepts/whatsapp-hosting": "/messages/concepts/whatsapp#whatsapp-number-hosting"


### PR DESCRIPTION
## Description

Adding a redirect from `/messages/concepts/whatsapp-hosting` (a non-existent page for which the URL is currently hard-coded in a 'Find out more' link in the customer Dashboard (as part of the flow when users sign up for a WhatsApp Business Account) to `/messages/concepts/whatsapp#whatsapp-number-hosting`  where the relevant information is actually located.

This is a temporary workaround (the Dashboard team will eventually update the hard-coded url in the Dashboard)

## Deploy Notes

Added an entry to `lib/nexmo_developer/config/redirects.yml` 
