### PR TITLE
APIDOC-174: feature blog img is now display in full

### DIFF
--- a/lib/nexmo_developer/app/views/blog/blogpost/show.html.erb
+++ b/lib/nexmo_developer/app/views/blog/blogpost/show.html.erb
@@ -60,7 +60,7 @@
     <div id="content" class="Vlt-card Vlt-bg-white">
 
       <!-- Header IMG -->
-      <div class="border-radius-top card-header-image" style="background-image: url(<%= @blogpost.header_img_url %>);"></div>
+      <div><%= image_tag @blogpost.header_img_url, class: "border-radius-top" %></div>
 
       <div class="Vlt-card__content" style="padding:24px;">
 


### PR DESCRIPTION
## Description

Header blogpost img is now display in **full size** - rather than:

<img width="355" alt="image" src="https://user-images.githubusercontent.com/34283479/165059956-570eab7c-a088-49ec-9d24-c0620a2de0fb.png">

