### PR TITLE
Added two CDN links to libraries needed for map, works locally

### DIFF
--- a/lib/nexmo_developer/app/views/static/default_landing/partials/_events.html.erb
+++ b/lib/nexmo_developer/app/views/static/default_landing/partials/_events.html.erb
@@ -1,6 +1,8 @@
 <script src="//maps.google.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>"></script>
 <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
 <script src='//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js' type='text/javascript'></script>
+<script src='//cdn.jsdelivr.net/gmaps4rails/2.1.2/gmaps4rails.js'> </script>
+<script src='//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore.js'> </script>
 
 <% all_remote = @upcoming_events.map(&:remote).all? %>
 <% feed = link_to 'Subscribe to feed', feeds_events_url(protocol: :webcal, format: :ics), class: 'Vlt-btn Vlt-btn--large Vlt-btn--secondary Vlt-btn--app' %>


### PR DESCRIPTION
## Description

Not sure what's going on here. But I found[ this StackOverlow ](https://stackoverflow.com/questions/44704324/gmaps-is-not-defined)with someone with the same problem. I added the js CDN links to the two libraries and it is working locally, before it was broken in local as well.

Overall, as the [gem](https://github.com/apneadiving/Google-Maps-for-Rails) we rely on for google maps isn't being maintained, I think we should try to integrate this solution with StimulusJS. However as adding StimulusJS is a big dependency and we will need to rewrite some existing code, I think we should incorporate these 2 CDN libraries for a quick fix and not have a broken map on the site anymore. 
