### PR TITLE
FIX: Display correctly <li> in blogpost

### DIFF
--- a/lib/nexmo_developer/app/assets/stylesheets/blog/blog.scss
+++ b/lib/nexmo_developer/app/assets/stylesheets/blog/blog.scss
@@ -134,7 +134,7 @@
 .raw_blopost_content {
   margin-top: 3em;
 
-  p {
+  p, li {
     font-size: 1.8rem;
     letter-spacing: 0.5px;
     color: #374151;


### PR DESCRIPTION
## Description

- Now `<li>` use the same format/style of blogpost `text`
