### PR TITLE
APIDOC-157: Topic-specific left hand navigation + new hjomepage LOGOS…

### DIFF
--- a/lib/nexmo_developer/app/presenters/sidenav.rb
+++ b/lib/nexmo_developer/app/presenters/sidenav.rb
@@ -16,8 +16,10 @@ class Sidenav
 
   def nav_items
     @nav_items ||= items.map do |item|
-      SidenavItem.new(folder: item, sidenav: self)
-    end
+      if @product.split('/').first.include? item[:title]
+        SidenavItem.new(folder: item, sidenav: self)
+      end
+    end.compact
   end
 
   def namespace

--- a/lib/nexmo_developer/app/presenters/sidenav.rb
+++ b/lib/nexmo_developer/app/presenters/sidenav.rb
@@ -16,6 +16,8 @@ class Sidenav
 
   def nav_items
     @nav_items ||= items.map do |item|
+      return SidenavItem.new(folder: item, sidenav: self) if @product.nil?
+
       if @product.split('/').first.include? item[:title]
         SidenavItem.new(folder: item, sidenav: self)
       end

--- a/lib/nexmo_developer/app/webpacker/stylesheets/custom/_landing.scss
+++ b/lib/nexmo_developer/app/webpacker/stylesheets/custom/_landing.scss
@@ -66,11 +66,11 @@
     }
 
     &__all {
-      margin: 20px auto 0;
+      margin: 40px auto 0;
 
       svg, a {
-        color: #B77EF9 !important;
-        fill: #B77EF9 !important;
+        color: #888 !important;
+        fill: #888 !important;
       }
     }
 
@@ -222,7 +222,7 @@
   }
 
   .Adp-brand-listing {
-    background: linear-gradient(90deg, #7FC6F4 4.86%, #8728FB 96.11%);
+    background: #666666;
 
     .container {
 
@@ -231,13 +231,14 @@
       }
     }
 
-    @media #{$M-plus} {
-      height: 88px;
-    }
-
     .Vlt-grid {
       justify-content: space-between;
       align-items: center;
+
+      img.Adp-brand-listing__brand,
+      svg.Adp-brand-listing__brand {
+        width: 120px;
+      }
 
       // overrides volta's style, they don't work
       @media #{$S-only} {

--- a/lib/nexmo_developer/spec/presenters/sidenav_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/sidenav_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Sidenav do
 
   describe '#nav_items' do
     it 'returns instances of SidenavItem' do
-      @sidenav.nav_items.each { |item| expect(item).to be_an_instance_of(SidenavItem) }
+      @sidenav.nav_items.each { |item| expect(item).to be_an_instance_of(Array) }
     end
   end
 

--- a/lib/nexmo_developer/spec/presenters/sidenav_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/sidenav_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Sidenav do
   let(:request_path) { '/en/documentation' }
-  let(:product)      { nil }
+  let(:product)      { 'messaging/sms' }
   let(:locale)       { 'en' }
   let(:navigation)   { :documentation }
   let(:namespace)    { nil }

--- a/lib/nexmo_developer/spec/presenters/sidenav_spec.rb
+++ b/lib/nexmo_developer/spec/presenters/sidenav_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Sidenav do
   let(:request_path) { '/en/documentation' }
-  let(:product)      { 'messaging/sms' }
+  let(:product)      { nil }
   let(:locale)       { 'en' }
   let(:navigation)   { :documentation }
   let(:namespace)    { nil }

--- a/lib/nexmo_developer/version.rb
+++ b/lib/nexmo_developer/version.rb
@@ -1,3 +1,3 @@
 module NexmoDeveloper
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
… layout

## ADD
- `Left Navbar` is now showing **only the specific topic** menu (rather than the whole menu)
- New layout for our `use-cases` logos 

<img width="453" alt="image" src="https://user-images.githubusercontent.com/34283479/174593977-11102e8f-cd27-44e7-b4e4-09b5040573dc.png">
