### PR TITLE
APIDOC-168: Topic-specific left hand navigation

### DIFF
--- a/lib/nexmo_developer/app/presenters/sidenav.rb
+++ b/lib/nexmo_developer/app/presenters/sidenav.rb
@@ -16,8 +16,10 @@ class Sidenav
 
   def nav_items
     @nav_items ||= items.map do |item|
-      SidenavItem.new(folder: item, sidenav: self)
-    end
+      if @product && @product.split('/').first.include?(item[:title])
+        SidenavItem.new(folder: item, sidenav: self)
+      end
+    end.compact
   end
 
   def namespace


### PR DESCRIPTION
## NEW
- display the contents associated with that main topic

<img width="290" alt="image" src="https://user-images.githubusercontent.com/34283479/175050586-1f48069b-ec7e-4e96-8044-eedd4f63d509.png">

