### PR TITLE
APIDOC-168: bigger clickable area for cards in /documentation

### DIFF
--- a/lib/nexmo_developer/app/views/static/landing_page_documentation/partials/_small_product_card.html.erb
+++ b/lib/nexmo_developer/app/views/static/landing_page_documentation/partials/_small_product_card.html.erb
@@ -1,13 +1,15 @@
 <div class="Vlt-card" style="padding: 35px;">
   <div class="d-flex-column h-100">
 
-    <div>
-      <svg class="Vlt-icon Vlt-icon--larger Vlt-purple"><use xlink:href="/symbol/volta-icons.svg#<%= product['icon'] %>" /></svg>
-    </div>
+    <a href=<%= product['product_name_link'] %>>
+      <div>
+        <svg class="Vlt-icon Vlt-icon--larger Vlt-purple"><use xlink:href="/symbol/volta-icons.svg#<%= product['icon'] %>" /></svg>
+      </div>
 
-    <h3 class="Vlt-purple">
-      <a href=<%= product['product_name_link'] %>><%= product['product_name'] %></a>
-    </h3>
+      <h3 class="Vlt-purple">
+        <%= product['product_name'] %>
+      </h3>
+    </a>
 
     <div style="flex-grow: 1; padding: 25px 0;">
       <p><%= raw product['product_description'].html_safe %></p>


### PR DESCRIPTION
### FIX

- bigger clickable aread for CARDS in `/documentation`

<img width="242" alt="image" src="https://user-images.githubusercontent.com/34283479/175065950-c038f8e0-0472-490c-8659-f0ee251d5579.png">

