### PR TITLE
APIDOC-168: Removed cache + bump version

### DIFF
--- a/lib/nexmo_developer/app/views/layouts/documentation.html.erb
+++ b/lib/nexmo_developer/app/views/layouts/documentation.html.erb
@@ -13,9 +13,7 @@
       </div>
       <div class="Vlt-sidenav__scroll">
         <nav class="sidenav" id="sidenav" data-active="<%= active_sidenav_item %>" aria-label="Documentation">
-          <% cache_unless params[:namespace].present?, ['sidenav', I18n.locale] do %>
             <%= render partial: 'layouts/partials/sidenav' %>
-          <% end %>
         </nav>
       </div>
     </div>

--- a/lib/nexmo_developer/version.rb
+++ b/lib/nexmo_developer/version.rb
@@ -1,3 +1,3 @@
 module NexmoDeveloper
-  VERSION = '0.4.3'.freeze
+  VERSION = '0.4.4'.freeze
 end


### PR DESCRIPTION
### FIX
- removed `cache` from `<navbar>`
- bumbed station ~> `v0.4.4`