### PR TITLE
Remove extra margin-top in homepage from XS screen

### DIFF
--- a/lib/nexmo_developer/app/webpacker/stylesheets/custom/_landing.scss
+++ b/lib/nexmo_developer/app/webpacker/stylesheets/custom/_landing.scss
@@ -38,10 +38,6 @@
 
     margin-top: 30px;
 
-    @media #{$S-only} {
-      margin-top: 300px;
-    }
-
     &__background {
       position: absolute;
       width: 100%;


### PR DESCRIPTION
### REMOVE
- extra `margin-top` in homepage for **XS screen**
<img width="233" alt="image" src="https://user-images.githubusercontent.com/34283479/177582441-db5aba57-3527-4297-a25e-a7dca8a94d4e.png">

