### PR TITLE
Team profile

### DIFF
--- a/lib/nexmo_developer/app/presenters/code_snippets_home_presenter.rb
+++ b/lib/nexmo_developer/app/presenters/code_snippets_home_presenter.rb
@@ -1,17 +1,6 @@
 class CodeSnippetsHomePresenter
   def code_snippets
-    @code_snippets ||= config['code_snippets'].map do |snippet|
-      OpenStruct.new(
-        html: Nexmo::Markdown::Renderer.new.call(
-          <<-STRING
-          ```code_snippets
-          source: '#{snippet['source']}'
-          ```
-          STRING
-        ),
-        title: snippet['title']
-      )
-    end
+    @code_snippets = []
   end
 
   def cache_key

--- a/lib/nexmo_developer/app/views/static/_profile.html.erb
+++ b/lib/nexmo_developer/app/views/static/_profile.html.erb
@@ -1,5 +1,6 @@
+
 <div class="Nxd-profile Vlt-col Vlt-col--M-1of3">
-  <%= image_tag(member.image_url, size: 140, class: 'Nxd-profile__avatar avatar') %>
+  <%= image_tag(member.url, size: 140, class: 'Nxd-profile__avatar avatar') %>
   <h3><%= member.name %></h3>
   <p class="Vlt-grey-darker p-large"><%= member.title ? member.title : 'Developer Advocate' %>
     <% if blog_author_path(member.short_name) %>

--- a/lib/nexmo_developer/config/code_languages.yml
+++ b/lib/nexmo_developer/config/code_languages.yml
@@ -1,0 +1,1 @@
+/Users/baronov/code/ruskibenya/nexmo-developer/config/code_languages.yml


### PR DESCRIPTION
## Description

The images for many profiles on [developer.vonage.com/team](developer.vonage.com/team) are breaking.

It seems when we stopped calling the .build_avatar_url method in the static_controller, it broke the use of member.image_url in the view. It broke on the else statement in build_avatar_url which stores the image in Cloudfront. 

Instead, using now member.url to display author images. Just as is used in the author show page.