### PR TITLE
APIDOC-295: fix /tutorials when URL is without params['products']

### DIFF
--- a/lib/nexmo_developer/app/controllers/tutorial_controller.rb
+++ b/lib/nexmo_developer/app/controllers/tutorial_controller.rb
@@ -61,13 +61,15 @@ class TutorialController < ApplicationController
   end
 
   def set_sidenav
+    @sidenav_product = params[:product] || @tutorial.yaml['products'].first
+
     @sidenav = Sidenav.new(
       namespace: params[:namespace],
       locale: params[:locale],
       request_path: request.path,
       navigation: @navigation,
       code_language: params[:code_language],
-      product: params[:product]
+      product: @sidenav_product
     )
   end
 

--- a/lib/nexmo_developer/app/helpers/application_helper.rb
+++ b/lib/nexmo_developer/app/helpers/application_helper.rb
@@ -17,7 +17,7 @@ module ApplicationHelper
 
   def active_sidenav_item
     if params[:tutorial_name]
-      url_for(controller: :tutorial, action: :index, product: params[:product], tutorial_name: params[:tutorial_name])
+      url_for(controller: :tutorial, action: :index, product: params[:product] || @sidenav_product, tutorial_name: params[:tutorial_name])
     else
       request.path.chomp("/#{params[:code_language]}")
     end

--- a/lib/nexmo_developer/spec/controllers/tutorial_controller_spec.rb
+++ b/lib/nexmo_developer/spec/controllers/tutorial_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe TutorialController, type: :controller do
   it 'renders' do
-    get :list, params: { product: 'messaging/sms'}
+    get :list, params: { product: 'messaging/sms' }
 
     expect(response.status).to eq(200)
   end

--- a/lib/nexmo_developer/spec/controllers/tutorial_controller_spec.rb
+++ b/lib/nexmo_developer/spec/controllers/tutorial_controller_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 RSpec.describe TutorialController, type: :controller do
   it 'renders' do
-    get :list
+    get :list, params: { product: 'messaging/sms'}
 
     expect(response.status).to eq(200)
   end
 
   describe 'when a locale is present' do
     it 'redirects to the canonical url if locale is :en' do
-      get :list, params: { locale: 'en' }
+      get :list, params: { locale: 'en', product: '' }
 
       expect(response).to redirect_to('/tutorials')
     end
 
     it 'renders when locale is different from :en' do
-      get :list, params: { locale: 'cn' }
+      get :list, params: { locale: 'cn', product: 'messaging/sms' }
 
       expect(response.status).to eq(200)
     end

--- a/lib/nexmo_developer/version.rb
+++ b/lib/nexmo_developer/version.rb
@@ -1,3 +1,3 @@
 module NexmoDeveloper
-  VERSION = '0.4.8'.freeze
+  VERSION = '0.4.9'.freeze
 end


### PR DESCRIPTION
### FIX
- Display side navbar when tutorial URL is without `PRODUCT` params
`/tutorials/in-app-messaging/introduction` vs `client-sdk/tutorials/in-app-messaging/introduction`
