### PR TITLE
APIDOC-295: Guard clause for tutorial product and params[product]

### DIFF
--- a/lib/nexmo_developer/app/controllers/tutorial_controller.rb
+++ b/lib/nexmo_developer/app/controllers/tutorial_controller.rb
@@ -61,7 +61,11 @@ class TutorialController < ApplicationController
   end
 
   def set_sidenav
-    @sidenav_product = params[:product] || @tutorial.yaml['products'].first
+    @sidenav_product = params[:product]
+
+    if @tutorial
+      @sidenav_product ||= @tutorial.yaml['products'].first
+    end
 
     @sidenav = Sidenav.new(
       namespace: params[:namespace],

--- a/lib/nexmo_developer/spec/controllers/tutorial_controller_spec.rb
+++ b/lib/nexmo_developer/spec/controllers/tutorial_controller_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 RSpec.describe TutorialController, type: :controller do
   it 'renders' do
-    get :list, params: { product: 'messaging/sms' }
+    get :list
 
     expect(response.status).to eq(200)
   end
 
   describe 'when a locale is present' do
     it 'redirects to the canonical url if locale is :en' do
-      get :list, params: { locale: 'en', product: '' }
+      get :list, params: { locale: 'en' }
 
       expect(response).to redirect_to('/tutorials')
     end
 
     it 'renders when locale is different from :en' do
-      get :list, params: { locale: 'cn', product: 'messaging/sms' }
+      get :list, params: { locale: 'cn' }
 
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
### FIX
- check the `product` from the `.MD` tutorial file if `params[product]` is `nil`
