### PR TITLE
FIX: removed MARGIN for <strong> tag (too much extra space) and make …

### DIFF
--- a/lib/nexmo_developer/app/assets/stylesheets/blog/blog.scss
+++ b/lib/nexmo_developer/app/assets/stylesheets/blog/blog.scss
@@ -146,9 +146,8 @@
     color: #374151;
     margin: 1em 0;
 
-    strong {
-      display: inline-block;
-      margin: 1em 0;
+    code {
+      font-size: 1.4rem;
     }
   }
 }


### PR DESCRIPTION
…<code> format smaller to not cover other text

### FIX

- **BOLD** is creating too much space
<img width="334" alt="image" src="https://user-images.githubusercontent.com/34283479/182817184-82d5ec20-b366-48e4-8837-91bd74037b8d.png">



- `CODE` is covering text
<img width="289" alt="image" src="https://user-images.githubusercontent.com/34283479/182817352-9400879b-5801-4e7a-8460-34f9d964847e.png">
