### PR TITLE
APIDOC-334: Link changelog to SDK release notes

### DIFF
--- a/lib/nexmo_developer/app/views/changelogs/index.html.erb
+++ b/lib/nexmo_developer/app/views/changelogs/index.html.erb
@@ -7,7 +7,8 @@
 
   <div class="my-3col-grid">
     <% title[:files].each do |file| %>
-      <%= link_to changelog_path(folder: title[:title], name: file[:file_title]), class: 'Vlt-card Vlt-card--clickable' do%>
+      <% validate_link = file[:frontmatter]['redirect_to'].present? ? file[:frontmatter]['redirect_to'] : changelog_path(folder: title[:title], name: file[:file_title]) %>
+      <%= link_to validate_link, class: 'Vlt-card Vlt-card--clickable' do%>
 
         <div class="Vlt-card__header">
 


### PR DESCRIPTION
### ADD
- added logic to redirect if `redirect_to` value is present in the markdown files

```
---
version: '4.0.3'
release: '4 Apr 2022'
redirect_to: '/client-sdk/sdk-documentation/android/release-notes'
---
```