### PR TITLE
Add AI Studio tag to Tag Parser

### DIFF
--- a/lib/nexmo_developer/app/services/tag_parser.rb
+++ b/lib/nexmo_developer/app/services/tag_parser.rb
@@ -8,6 +8,7 @@ class TagParser
   # end
 
   TAGS_WITH_ICON = [
+    'ai-studio',
     'dispatch-api',
     'messages-api',
     'messages-api-sandbox',


### PR DESCRIPTION
## Description

Updating the `TAGS_WITH_ICON` constant in `TagParser` to add `ai-studio`.

